### PR TITLE
improvement: provide Logto APIs in one instance

### DIFF
--- a/android/library/src/main/java/io/logto/android/Logto.kt
+++ b/android/library/src/main/java/io/logto/android/Logto.kt
@@ -1,19 +1,82 @@
 package io.logto.android
 
+import android.app.Application
 import android.content.Context
 import io.logto.android.authflow.webview.WebViewAuthFlow
+import io.logto.android.callback.AuthenticationCallback
+import io.logto.android.config.LogtoConfig
 import io.logto.android.model.Credential
 import io.logto.android.storage.CredentialStorage
 
-class Logto {
-    companion object {
-        private var credentialStorage: CredentialStorage? = null
+class Logto private constructor() {
 
-        fun webViewAuthFlow(context: Context): WebViewAuthFlow {
-            credentialStorage = CredentialStorage(context.applicationContext)
-            return WebViewAuthFlow(context, credentialStorage)
+    private lateinit var logtoConfig: LogtoConfig
+
+    private lateinit var application: Application
+
+    private var inited: Boolean = false
+
+    private var useStorage: Boolean = false
+
+    private var credentialStorage: CredentialStorage? = null
+
+    private var _credential: Credential? = null
+
+    val credential: Credential?
+        get() = credentialStorage?.getCredential() ?: _credential
+
+    fun init(
+        application: Application,
+        logtoConfig: LogtoConfig,
+        useStorage: Boolean = false
+    ) {
+        this.application = application
+        this.logtoConfig = logtoConfig
+        this.useStorage = useStorage
+        if (this.useStorage) {
+            credentialStorage = CredentialStorage(application)
         }
+        inited = true
+    }
 
-        fun getCredential(): Credential? = credentialStorage?.getCredential()
+    fun loginWithWebView(
+        context: Context,
+        onComplete: (credential: Credential?, error: Error?) -> Unit
+    ) {
+        checkInitState()
+        WebViewAuthFlow(
+            context,
+            logtoConfig,
+            object : AuthenticationCallback {
+                override fun onSuccess(result: Credential) {
+                    _credential = result
+                    credentialStorage?.saveCredential(result)
+                    onComplete(result, null)
+                }
+
+                override fun onFailed(error: Error) {
+                    onComplete(null, error)
+                }
+            }
+        ).startAuth()
+    }
+
+    private fun checkInitState() {
+        if (!inited) {
+            throw Exception("Logto singleton is not initialized!")
+        }
+    }
+
+    companion object {
+        private lateinit var INSTANCE: Logto
+
+        fun getInstance(): Logto {
+            synchronized(Logto::class.java) {
+                if (!::INSTANCE.isInitialized) {
+                    INSTANCE = Logto()
+                }
+                return INSTANCE
+            }
+        }
     }
 }

--- a/android/library/src/main/java/io/logto/android/Logto.kt
+++ b/android/library/src/main/java/io/logto/android/Logto.kt
@@ -41,7 +41,7 @@ class Logto private constructor() {
 
     fun loginWithWebView(
         context: Context,
-        onComplete: (credential: Credential?, error: Error?) -> Unit
+        onComplete: (error: Error?, credential: Credential?) -> Unit
     ) {
         checkInitState()
         WebViewAuthFlow(
@@ -51,11 +51,11 @@ class Logto private constructor() {
                 override fun onSuccess(result: Credential) {
                     _credential = result
                     credentialStorage?.saveCredential(result)
-                    onComplete(result, null)
+                    onComplete(null, result)
                 }
 
                 override fun onFailed(error: Error) {
-                    onComplete(null, error)
+                    onComplete(error, null)
                 }
             }
         ).startAuth()

--- a/android/library/src/main/java/io/logto/android/client/LogtoClientBuilder.kt
+++ b/android/library/src/main/java/io/logto/android/client/LogtoClientBuilder.kt
@@ -2,8 +2,8 @@ package io.logto.android.client
 
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.GsonBuilder
-import io.logto.android.LogtoConfig
 import io.logto.android.client.api.LogtoClient
+import io.logto.android.config.LogtoConfig
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 

--- a/android/library/src/main/java/io/logto/android/config/LogtoConfig.kt
+++ b/android/library/src/main/java/io/logto/android/config/LogtoConfig.kt
@@ -1,4 +1,4 @@
-package io.logto.android
+package io.logto.android.config
 
 data class LogtoConfig(
     val clientId: String,

--- a/android/library/src/test/java/io/logto/android/LogtoConfigTest.kt
+++ b/android/library/src/test/java/io/logto/android/LogtoConfigTest.kt
@@ -1,5 +1,6 @@
 package io.logto.android
 
+import io.logto.android.config.LogtoConfig
 import io.logto.android.constant.AuthConstant
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`


### PR DESCRIPTION
## Summary
This pr move all exported logto apis into one class which makes this library easier to use and less error-prone.

before: 
```kotlin
private fun startLogin() {
    val logtoConfig = LogtoConfig(
        clientId = "foo",
        oidcEndpoint = "$END_POINT",
        scopes = listOf(
            AuthConstant.ScopeValue.OPEN_ID,
            AuthConstant.ScopeValue.OFFLINE_ACCESS
        ),
        redirectUri = "$REDIRECT_URI"
    )

    Logto
        .webViewAuthFlow(this)
        .login(logtoConfig)
        .start(
            this,
            object : AuthenticationCallback {
                override fun onSuccess(result: Credential) {
                    Log.d(TAG, "Credential: $result")
                }

                override fun onFailed(error: Error) {
                    Log.d(TAG, "Auth Failed")
                }
            }
        )
}

```

after:
```kotlin
fun init() {
    Logto.getInstance().init(application, LogtoConfig(
            clientId = "foo",
            oidcEndpoint = "$END_POINT",
            scopes = listOf(
                AuthConstant.ScopeValue.OPEN_ID,
                AuthConstant.ScopeValue.OFFLINE_ACCESS
            ),
            redirectUri = "$REDIRECT_URI"
        )
    )
}

fun startLogin() {
    Logto.getInstance().loginWithWebView(this) { error, credential ->
        error?.let { Log.d(TAG, "Auth Failed") }
        credential?.let { Log.d(TAG, "Credential: $credential") }
    }
}
```