### PR TITLE
Improvement: use hash to make `logtoConfig` key unique

### DIFF
--- a/android/library/src/main/java/io/logto/android/config/LogtoConfig.kt
+++ b/android/library/src/main/java/io/logto/android/config/LogtoConfig.kt
@@ -10,6 +10,9 @@ data class LogtoConfig(
     val encodedScopes: String
         get() = scopes.joinToString(" ")
 
+    val cacheKey: String
+        get() = "$clientId:$encodedScopes"
+
     private fun validate() {
         require(domain.isNotEmpty()) { "LogtoConfig: domain should not be empty" }
         require(clientId.isNotEmpty()) { "LogtoConfig: clientId should not be empty" }

--- a/android/library/src/main/java/io/logto/android/storage/TokenSetStorage.kt
+++ b/android/library/src/main/java/io/logto/android/storage/TokenSetStorage.kt
@@ -24,7 +24,7 @@ class TokenSetStorage(
         }
 
     private val sharedPreferenceName =
-        "$SHARED_PREFERENCE_NAME_PREFIX:${Utils.generateHash(logtoConfig.toString())}"
+        "$SHARED_PREFERENCE_NAME_PREFIX:${logtoConfig.cacheKey}"
 
     private val sharedPreferences by lazy {
         context.getSharedPreferences(sharedPreferenceName, Context.MODE_PRIVATE)

--- a/android/library/src/main/java/io/logto/android/utils/Utils.kt
+++ b/android/library/src/main/java/io/logto/android/utils/Utils.kt
@@ -52,16 +52,4 @@ object Utils {
             throw LogtoException(LogtoException.INVALID_JWT, exception)
         }
     }
-
-    fun generateHash(input: String, length: Int = 6): String {
-        val hashStr = MessageDigest.getInstance("SHA-256")
-            .digest(input.toByteArray())
-            .fold("") { str, it ->
-                str + "%02x".format(it)
-            }
-        if (hashStr.length < length) {
-            return hashStr
-        }
-        return hashStr.substring(0, length)
-    }
 }


### PR DESCRIPTION
## Summary
* Improvement: use hash to make `logtoConfig` key unique


<!-- Optional -->
## Linear Issue Reference
* [LOG-151: Process correctly when use the same logtoConfig to instantiate Logto instance twice](https://linear.app/silverhand/issue/LOG-151/enhance-process-correctly-when-use-the-same-logtoconfig-to-instantiate)
* [LOG-150: use hash to make logto config key unique](https://linear.app/silverhand/issue/LOG-150/improvement-use-hash-to-make-logto-config-key-unique)
