### PR TITLE
fix: calculate tokenSet expiresAt on granted

### DIFF
--- a/android/library/src/main/java/io/logto/android/client/LogtoAndroidClient.kt
+++ b/android/library/src/main/java/io/logto/android/client/LogtoAndroidClient.kt
@@ -57,6 +57,7 @@ class LogtoAndroidClient(
                 authorizationCode,
                 codeVerifier
             ).apply {
+                calculateExpiresAt()
                 validateIdToken(logtoConfig.clientId, jwks)
             }
             block(null, tokenSet)
@@ -76,6 +77,7 @@ class LogtoAndroidClient(
                 oidcConfiguration.tokenEndpoint,
                 refreshToken
             ).apply {
+                calculateExpiresAt()
                 validateIdToken(logtoConfig.clientId, jwks)
             }
             block(null, tokenSet)

--- a/android/library/src/main/java/io/logto/client/model/TokenSet.kt
+++ b/android/library/src/main/java/io/logto/client/model/TokenSet.kt
@@ -12,9 +12,15 @@ data class TokenSet(
     val tokenType: String,
     private val expiresIn: Long,
 ) {
-    var expiresAt: Long = TimeUtils.expiresAtFromNow(expiresIn)
+    var expiresAt: Long = 0L
+
     fun isExpired(): Boolean = TimeUtils.nowRoundToSec() >= expiresAt
+
     fun expiresInSeconds(): Long = (expiresAt - TimeUtils.nowRoundToSec()).coerceAtLeast(0L)
+
+    fun calculateExpiresAt() {
+        expiresAt = TimeUtils.expiresAtFromNow(expiresIn)
+    }
 
     fun validateIdToken(
         clientId: String,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
`Gson` will not call constructor of data class `TokenSet` during serialization process which makes us loose our expiresAt value in tokenSet. (ref: [Why Kotlin data classes can have nulls in non-nullable fields with Gson?](https://stackoverflow.com/questions/52837665/why-kotlin-data-classes-can-have-nulls-in-non-nullable-fields-with-gson))

Another 3rd json serialization lib intergated with ktor, Jackson, has the same problem.

We can use `kotlinx.serilazation.json` to solve this problem, but `kotlinx.serilazation.json` don't support [json properties naming configuration](https://github.com/Kotlin/kotlinx.serialization/issues/33).

So, we need to call `TokenSet`'s method `calculateExpiresAt` explicitly once we grant it from backend.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* [Bug: Gson should call `TokenSet`'s constructor (LOG-266)](https://linear.app/silverhand/issue/LOG-266/bug-gson-should-call-tokensets-constructor)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
before:
<img width="301" alt="before" src="https://user-images.githubusercontent.com/10806653/142144148-3cab60c4-f2a9-4d70-8d87-6f0a93518eba.png">
after:
<img width="374" alt="after" src="https://user-images.githubusercontent.com/10806653/142144183-cdba5e03-b54a-446c-8297-4c7c5a2a04f6.png">


