### PR TITLE
fix: should handle user cancel in browser flow

### DIFF
--- a/android/library/src/main/java/io/logto/android/auth/AuthManager.kt
+++ b/android/library/src/main/java/io/logto/android/auth/AuthManager.kt
@@ -15,6 +15,11 @@ object AuthManager {
         currentFlow?.handleRedirectUri(redirectUri)
     }
 
+    fun handleUserCanceled() {
+        currentFlow?.handleUserCanceled()
+        currentFlow = null
+    }
+
     fun reset() {
         currentFlow = null
     }

--- a/android/library/src/main/java/io/logto/android/auth/IFlow.kt
+++ b/android/library/src/main/java/io/logto/android/auth/IFlow.kt
@@ -6,4 +6,5 @@ import android.net.Uri
 interface IFlow {
     fun start(context: Context)
     fun handleRedirectUri(redirectUri: Uri)
+    fun handleUserCanceled()
 }

--- a/android/library/src/main/java/io/logto/android/auth/activity/AuthorizationActivity.kt
+++ b/android/library/src/main/java/io/logto/android/auth/activity/AuthorizationActivity.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
+import io.logto.android.auth.AuthManager
 
 class AuthorizationActivity : AppCompatActivity() {
 
@@ -47,14 +48,20 @@ class AuthorizationActivity : AppCompatActivity() {
 
     private fun handleFlow() {
         if (flowStarted) {
+            val flowComplete = intent.getBooleanExtra(EXTRA_FLOW_COMPLETE_FLAG, false)
+            if (!flowComplete) {
+                AuthManager.handleUserCanceled()
+            }
             handleFlowEnd()
             return
         }
+
         val endpoint = intent.getStringExtra(EXTRA_FLOW_ENDPOINT)
         if (endpoint == null) {
             handleFlowEnd()
             return
         }
+
         handleFlowStart(endpoint)
     }
 
@@ -90,6 +97,7 @@ class AuthorizationActivity : AppCompatActivity() {
     companion object {
         private const val EXTRA_FLOW_ENDPOINT = "EXTRA_FLOW_ENDPOINT"
         private const val EXTRA_FLOW_REDIRECT_URI = "EXTRA_FLOW_REDIRECT_URI"
+        private const val EXTRA_FLOW_COMPLETE_FLAG = "EXTRA_FLOW_COMPLETE_FLAG"
 
         fun createHandleStartIntent(
             context: Context,
@@ -100,6 +108,7 @@ class AuthorizationActivity : AppCompatActivity() {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
                 putExtra(EXTRA_FLOW_ENDPOINT, endpoint)
                 putExtra(EXTRA_FLOW_REDIRECT_URI, redirectUri)
+                putExtra(EXTRA_FLOW_COMPLETE_FLAG, false)
             }
         }
 
@@ -108,6 +117,7 @@ class AuthorizationActivity : AppCompatActivity() {
         ): Intent {
             return Intent(context, AuthorizationActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                putExtra(EXTRA_FLOW_COMPLETE_FLAG, true)
             }
         }
     }

--- a/android/library/src/main/java/io/logto/android/auth/browser/BrowserSignInFlow.kt
+++ b/android/library/src/main/java/io/logto/android/auth/browser/BrowserSignInFlow.kt
@@ -11,6 +11,7 @@ import io.logto.client.constant.QueryKey
 import io.logto.client.exception.LogtoException
 import io.logto.client.exception.LogtoException.Companion.MISSING_AUTHORIZATION_CODE
 import io.logto.client.exception.LogtoException.Companion.SIGN_IN_FAILED
+import io.logto.client.exception.LogtoException.Companion.USER_CANCELED
 import io.logto.client.utils.PkceUtils
 
 class BrowserSignInFlow(
@@ -60,5 +61,9 @@ class BrowserSignInFlow(
         ) { exception, tokenSet ->
             onComplete(exception, tokenSet)
         }
+    }
+
+    override fun handleUserCanceled() {
+        onComplete(LogtoException(USER_CANCELED), null)
     }
 }

--- a/android/library/src/main/java/io/logto/android/auth/browser/BrowserSignOutFlow.kt
+++ b/android/library/src/main/java/io/logto/android/auth/browser/BrowserSignOutFlow.kt
@@ -9,6 +9,7 @@ import io.logto.android.client.LogtoAndroidClient
 import io.logto.android.utils.Utils
 import io.logto.client.exception.LogtoException
 import io.logto.client.exception.LogtoException.Companion.SIGN_OUT_FAILED
+import io.logto.client.exception.LogtoException.Companion.USER_CANCELED
 
 class BrowserSignOutFlow(
     private val idToken: String,
@@ -45,5 +46,9 @@ class BrowserSignOutFlow(
             return
         }
         onComplete(null)
+    }
+
+    override fun handleUserCanceled() {
+        onComplete(LogtoException(USER_CANCELED))
     }
 }

--- a/android/library/src/main/java/io/logto/client/exception/LogtoException.kt
+++ b/android/library/src/main/java/io/logto/client/exception/LogtoException.kt
@@ -20,5 +20,6 @@ class LogtoException(
         const val INVALID_JWKS_JSON = "Invalid jwks json"
         const val ENCRYPT_ALGORITHM_NOT_SUPPORTED = "Encrypt Algorithm Not Supported"
         const val CODE_CHALLENGE_ENCODED_FAILED = "Code challenge encoded failed"
+        const val USER_CANCELED = "User canceled"
     }
 }

--- a/android/library/src/test/java/io/logto/android/auth/AuthManagerTest.kt
+++ b/android/library/src/test/java/io/logto/android/auth/AuthManagerTest.kt
@@ -26,20 +26,34 @@ class AuthManagerTest {
         verify(testFlow).handleRedirectUri(testUriData)
 
         AuthManager.reset()
-        assertThat(AuthManager.currentFlow).isEqualTo(null)
+        assertThat(AuthManager.currentFlow).isNull()
     }
 
     @Test
     fun authManagerHandleRedirectUri() {
         AuthManager.start(context, testFlow)
+
         AuthManager.handleRedirectUri(testUriData)
+
         verify(testFlow).handleRedirectUri(testUriData)
     }
 
     @Test
     fun authManagerOnReset() {
         AuthManager.start(context, testFlow)
+
         AuthManager.reset()
-        assertThat(AuthManager.currentFlow).isEqualTo(null)
+
+        assertThat(AuthManager.currentFlow).isNull()
+    }
+
+    @Test
+    fun authManagerHandleUserCanceled() {
+        AuthManager.start(context, testFlow)
+
+        AuthManager.handleUserCanceled()
+
+        verify(testFlow).handleUserCanceled()
+        assertThat(AuthManager.currentFlow).isNull()
     }
 }

--- a/android/library/src/test/java/io/logto/android/auth/AuthManagerTest.kt
+++ b/android/library/src/test/java/io/logto/android/auth/AuthManagerTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -15,6 +16,11 @@ class AuthManagerTest {
     private val context = ApplicationProvider.getApplicationContext<Application>()
     private val testFlow = mock(IFlow::class.java)
     private val testUriData = mock(Uri::class.java)
+
+    @After
+    fun tearDown() {
+        AuthManager.reset()
+    }
 
     @Test
     fun authManagerOnStart() {

--- a/android/library/src/test/java/io/logto/android/auth/browser/BrowserSignInFlowTest.kt
+++ b/android/library/src/test/java/io/logto/android/auth/browser/BrowserSignInFlowTest.kt
@@ -14,6 +14,7 @@ import io.logto.client.exception.LogtoException.Companion.EMPTY_REDIRECT_URI
 import io.logto.client.exception.LogtoException.Companion.INVALID_REDIRECT_URI
 import io.logto.client.exception.LogtoException.Companion.MISSING_AUTHORIZATION_CODE
 import io.logto.client.exception.LogtoException.Companion.SIGN_IN_FAILED
+import io.logto.client.exception.LogtoException.Companion.USER_CANCELED
 import io.logto.client.model.OidcConfiguration
 import io.logto.client.model.TokenSet
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -233,5 +234,12 @@ class BrowserSignInFlowTest {
         verify(onCompleteMock).invoke(logtoExceptionCaptor.capture(), tokenSetCaptor.capture())
         assertThat(logtoExceptionCaptor.firstValue).isEqualTo(mockLogtoException)
         assertThat(tokenSetCaptor.firstValue).isNull()
+    }
+
+    @Test
+    fun handleUserCanceledShouldCompleteWithLogtoException() {
+        browserSignInFlow.handleUserCanceled()
+        verify(onCompleteMock).invoke(logtoExceptionCaptor.capture(), tokenSetCaptor.capture())
+        assertThat(logtoExceptionCaptor.firstValue).hasMessageThat().isEqualTo(USER_CANCELED)
     }
 }

--- a/android/library/src/test/java/io/logto/android/auth/browser/BrowserSignOutFlowTest.kt
+++ b/android/library/src/test/java/io/logto/android/auth/browser/BrowserSignOutFlowTest.kt
@@ -13,6 +13,7 @@ import io.logto.client.exception.LogtoException
 import io.logto.client.exception.LogtoException.Companion.EMPTY_REDIRECT_URI
 import io.logto.client.exception.LogtoException.Companion.INVALID_REDIRECT_URI
 import io.logto.client.exception.LogtoException.Companion.SIGN_OUT_FAILED
+import io.logto.client.exception.LogtoException.Companion.USER_CANCELED
 import io.logto.client.model.OidcConfiguration
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -161,5 +162,14 @@ class BrowserSignOutFlowTest {
 
         verify(onCompleteMock).invoke(logtoExceptionCaptor.capture())
         assertThat(logtoExceptionCaptor.firstValue).isNull()
+    }
+
+    @Test
+    fun handleUserCanceledShouldCompleteWithLogtoException() {
+        browserSignOutFlow.handleUserCanceled()
+
+        verify(onCompleteMock).invoke(logtoExceptionCaptor.capture())
+
+        assertThat(logtoExceptionCaptor.firstValue).hasMessageThat().isEqualTo(USER_CANCELED)
     }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
* fix: should handle user cancel in browser flow

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* [Fix: reset AuthManager on user cancel (LOG-326)](https://linear.app/silverhand/issue/LOG-326/fix-reset-authmanager-on-user-cancel)
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
1. UT
2. Test sample:
![handle-cancel](https://user-images.githubusercontent.com/10806653/142389799-ab59d5ff-3cb2-4479-9998-18fdf77ff7c8.gif)
 
