### PR TITLE
chore(android): accurate naming scope and scope values

### DIFF
--- a/android/app/src/main/java/io/logto/demo/viewmodel/LogtoViewModel.kt
+++ b/android/app/src/main/java/io/logto/demo/viewmodel/LogtoViewModel.kt
@@ -82,7 +82,7 @@ class LogtoViewModel(application: Application) : AndroidViewModel(application) {
         val logtoConfig = LogtoConfig(
             domain = "logto.dev",
             clientId = "z4skkM1Z8LLVSl1JCmVZO",
-            scopes = listOf(
+            scopeValues = listOf(
                 ScopeValue.OPEN_ID,
                 ScopeValue.OFFLINE_ACCESS
             ),

--- a/android/library/src/main/java/io/logto/client/LogtoClient.kt
+++ b/android/library/src/main/java/io/logto/client/LogtoClient.kt
@@ -26,8 +26,8 @@ open class LogtoClient(
             parameters.append(QueryKey.PROMPT, PromptValue.CONSENT)
             parameters.append(QueryKey.REDIRECT_URI, logtoConfig.redirectUri)
             parameters.append(QueryKey.RESPONSE_TYPE, ResponseType.CODE)
-            parameters.append(QueryKey.SCOPE, logtoConfig.encodedScopes)
             parameters.append(QueryKey.RESOURCE, ResourceValue.LOGTO_API)
+            parameters.append(QueryKey.SCOPE, logtoConfig.scope)
         }
         return urlBuilder.buildString()
     }

--- a/android/library/src/main/java/io/logto/client/config/LogtoConfig.kt
+++ b/android/library/src/main/java/io/logto/client/config/LogtoConfig.kt
@@ -3,18 +3,18 @@ package io.logto.client.config
 data class LogtoConfig(
     val domain: String,
     val clientId: String,
-    val scopes: List<String>,
+    val scopeValues: List<String>,
     val redirectUri: String,
     val postLogoutRedirectUri: String,
 ) {
-    val encodedScopes: String = scopes.joinToString(" ")
+    val scope: String = scopeValues.joinToString(" ")
 
-    val cacheKey: String = "$clientId::$encodedScopes"
+    val cacheKey: String = "$clientId::$scope"
 
     private fun validate() {
         require(domain.isNotEmpty()) { "LogtoConfig: domain should not be empty" }
         require(clientId.isNotEmpty()) { "LogtoConfig: clientId should not be empty" }
-        require(scopes.isNotEmpty()) { "LogtoConfig: scope list should not be empty" }
+        require(scopeValues.isNotEmpty()) { "LogtoConfig: scopeValues should not be empty" }
         require(redirectUri.isNotEmpty()) { "LogtoConfig: redirectUri should not be empty" }
         require(postLogoutRedirectUri.isNotEmpty()) {
             "LogtoConfig: postLogoutRedirectUri should not be empty"

--- a/android/library/src/test/java/io/logto/android/storage/TokenSetStorageTest.kt
+++ b/android/library/src/test/java/io/logto/android/storage/TokenSetStorageTest.kt
@@ -17,7 +17,7 @@ class TokenSetStorageTest {
     private val logtoConfig = LogtoConfig(
         domain = "logto.dev",
         clientId = "clientId",
-        scopes = listOf(ScopeValue.OPEN_ID, ScopeValue.OFFLINE_ACCESS),
+        scopeValues = listOf(ScopeValue.OPEN_ID, ScopeValue.OFFLINE_ACCESS),
         redirectUri = "redirectUri",
         postLogoutRedirectUri = "postLogoutRedirectUri",
     )

--- a/android/library/src/test/java/io/logto/client/LogtoClientTest.kt
+++ b/android/library/src/test/java/io/logto/client/LogtoClientTest.kt
@@ -25,7 +25,7 @@ class LogtoClientTest {
     private val testLogtoConfig = LogtoConfig(
         domain = "logto.dev",
         clientId = "clientId",
-        scopes = listOf(ScopeValue.OFFLINE_ACCESS, ScopeValue.OPEN_ID),
+        scopeValues = listOf(ScopeValue.OFFLINE_ACCESS, ScopeValue.OPEN_ID),
         redirectUri = "redirectUri",
         postLogoutRedirectUri = "postLogoutRedirectUri"
     )
@@ -57,7 +57,7 @@ class LogtoClientTest {
             assertThat(parameters[QueryKey.CODE_CHALLENGE_METHOD]).isEqualTo(CodeChallengeMethod.S256)
             assertThat(parameters[QueryKey.PROMPT]).isEqualTo(PromptValue.CONSENT)
             assertThat(parameters[QueryKey.RESPONSE_TYPE]).isEqualTo(ResponseType.CODE)
-            assertThat(parameters[QueryKey.SCOPE]).isEqualTo(testLogtoConfig.encodedScopes)
+            assertThat(parameters[QueryKey.SCOPE]).isEqualTo(testLogtoConfig.scope)
             assertThat(parameters[QueryKey.RESOURCE]).isEqualTo(ResourceValue.LOGTO_API)
         }
     }

--- a/android/library/src/test/java/io/logto/client/config/LogtoConfigTest.kt
+++ b/android/library/src/test/java/io/logto/client/config/LogtoConfigTest.kt
@@ -12,7 +12,7 @@ class LogtoConfigTest {
         assertThat(logtoConfig).isNotNull()
         assertThat(logtoConfig.domain).isEqualTo(TEST_DOMAIN)
         assertThat(logtoConfig.clientId).isEqualTo(TEST_CLIENT_ID)
-        assertThat(logtoConfig.scopes).isEqualTo(TEST_SCOPE_ARRAY)
+        assertThat(logtoConfig.scopeValues).isEqualTo(TEST_SCOPE_VALUES)
         assertThat(logtoConfig.redirectUri).isEqualTo(TEST_REDIRECT_URI)
         assertThat(logtoConfig.postLogoutRedirectUri).isEqualTo(TEST_POST_LOGOUT_REDIRE_URI)
     }
@@ -23,7 +23,7 @@ class LogtoConfigTest {
             LogtoConfig(
                 domain = TEST_DOMAIN,
                 clientId = "",
-                scopes = TEST_SCOPE_ARRAY,
+                scopeValues = TEST_SCOPE_VALUES,
                 redirectUri = TEST_REDIRECT_URI,
                 postLogoutRedirectUri = TEST_POST_LOGOUT_REDIRE_URI,
             )
@@ -42,7 +42,7 @@ class LogtoConfigTest {
             LogtoConfig(
                 domain = TEST_DOMAIN,
                 clientId = TEST_CLIENT_ID,
-                scopes = listOf(),
+                scopeValues = listOf(),
                 redirectUri = TEST_REDIRECT_URI,
                 postLogoutRedirectUri = TEST_POST_LOGOUT_REDIRE_URI,
             )
@@ -58,7 +58,7 @@ class LogtoConfigTest {
             LogtoConfig(
                 domain = TEST_DOMAIN,
                 clientId = TEST_CLIENT_ID,
-                scopes = TEST_SCOPE_ARRAY,
+                scopeValues = TEST_SCOPE_VALUES,
                 redirectUri = "",
                 postLogoutRedirectUri = TEST_POST_LOGOUT_REDIRE_URI,
             )
@@ -74,7 +74,7 @@ class LogtoConfigTest {
             LogtoConfig(
                 domain = TEST_DOMAIN,
                 clientId = TEST_CLIENT_ID,
-                scopes = TEST_SCOPE_ARRAY,
+                scopeValues = TEST_SCOPE_VALUES,
                 redirectUri = TEST_REDIRECT_URI,
                 postLogoutRedirectUri = "",
             )
@@ -90,7 +90,7 @@ class LogtoConfigTest {
             LogtoConfig(
                 domain = "",
                 clientId = TEST_CLIENT_ID,
-                scopes = TEST_SCOPE_ARRAY,
+                scopeValues = TEST_SCOPE_VALUES,
                 redirectUri = TEST_REDIRECT_URI,
                 postLogoutRedirectUri = TEST_POST_LOGOUT_REDIRE_URI,
             )
@@ -100,7 +100,7 @@ class LogtoConfigTest {
     @Test
     fun encodedScopesValidation() {
         val logtoConfig = createTestLogtoConfig()
-        assertThat(logtoConfig.encodedScopes)
+        assertThat(logtoConfig.scope)
             .isEqualTo("${ScopeValue.OPEN_ID} ${ScopeValue.OFFLINE_ACCESS}")
     }
 
@@ -108,19 +108,19 @@ class LogtoConfigTest {
     fun cacheKeyValidation() {
         val logtoConfig = createTestLogtoConfig()
         assertThat(logtoConfig.cacheKey)
-            .isEqualTo("$TEST_CLIENT_ID::${logtoConfig.encodedScopes}")
+            .isEqualTo("$TEST_CLIENT_ID::${logtoConfig.scope}")
     }
 
     private val TEST_DOMAIN = "logto.dev"
     private val TEST_CLIENT_ID = "clientId"
-    private val TEST_SCOPE_ARRAY = listOf(ScopeValue.OPEN_ID, ScopeValue.OFFLINE_ACCESS)
+    private val TEST_SCOPE_VALUES = listOf(ScopeValue.OPEN_ID, ScopeValue.OFFLINE_ACCESS)
     private val TEST_REDIRECT_URI = "redirectUri"
     private val TEST_POST_LOGOUT_REDIRE_URI = "postLogoutRedirectUri"
 
     private fun createTestLogtoConfig() = LogtoConfig(
         domain = TEST_DOMAIN,
         clientId = TEST_CLIENT_ID,
-        scopes = TEST_SCOPE_ARRAY,
+        scopeValues = TEST_SCOPE_VALUES,
         redirectUri = TEST_REDIRECT_URI,
         postLogoutRedirectUri = TEST_POST_LOGOUT_REDIRE_URI,
     )


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

- Naming scope and scope values accurately. 

- Definitions

    - `scope value` : one of `openid`, `name`, `email` & etc.

    - `scope values` : array/list/set consisted of multiple `scope value`s

        - e.g. `["openid", "name", "email"]`

    - `scope` : the string consisted of `scope value`s joined by whitespaces

        - a non-normative example of a scope Request: `scope=openid profile email phone`

        _from https://www.rfc-editor.org/rfc/inline-errata/rfc6749.html session 3.3_

        > The value of the scope parameter is expressed as a space-delimited list of case-sensitive strings.
        
- References : https://openid.net/specs/openid-connect-basic-1_0.html#Scopes

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.