### PR TITLE
chore(android): url-encode cacheKey as same as js-sdk

### DIFF
--- a/android/library/src/main/java/io/logto/client/config/LogtoConfig.kt
+++ b/android/library/src/main/java/io/logto/client/config/LogtoConfig.kt
@@ -1,5 +1,7 @@
 package io.logto.client.config
 
+import java.net.URLEncoder
+
 data class LogtoConfig(
     val domain: String,
     val clientId: String,
@@ -9,7 +11,7 @@ data class LogtoConfig(
 ) {
     val encodedScopes: String = scopes.joinToString(" ")
 
-    val cacheKey: String = "$clientId::$encodedScopes"
+    val cacheKey: String = URLEncoder.encode("$clientId::$encodedScopes", "utf-8")
 
     private fun validate() {
         require(domain.isNotEmpty()) { "LogtoConfig: domain should not be empty" }

--- a/android/library/src/test/java/io/logto/client/config/LogtoConfigTest.kt
+++ b/android/library/src/test/java/io/logto/client/config/LogtoConfigTest.kt
@@ -108,7 +108,7 @@ class LogtoConfigTest {
     fun cacheKeyValidation() {
         val logtoConfig = createTestLogtoConfig()
         assertThat(logtoConfig.cacheKey)
-            .isEqualTo("$TEST_CLIENT_ID::${logtoConfig.encodedScopes}")
+            .isEqualTo("$TEST_CLIENT_ID%3A%3A${ScopeValue.OPEN_ID}+${ScopeValue.OFFLINE_ACCESS}")
     }
 
     private val TEST_DOMAIN = "logto.dev"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- Url-encode the cache key as same as JS SDK does.
    - But keep the default encoding rule of url-encoding in each environment
        - JS `encodeURLComponent` whitespace → `%20`
        - Java `java.net.URLEncoder.encode` : whitespace → `+`

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing code.
