### PR TITLE
refactor: move token validation logic to `logtoClient`

### DIFF
--- a/android/library/src/main/java/io/logto/android/client/LogtoAndroidClient.kt
+++ b/android/library/src/main/java/io/logto/android/client/LogtoAndroidClient.kt
@@ -9,15 +9,12 @@ import io.logto.android.callback.HandleTokenSetCallback
 import io.logto.client.LogtoClient
 import io.logto.client.config.LogtoConfig
 import io.logto.client.exception.LogtoException
-import io.logto.client.model.OidcConfiguration
 import io.logto.client.service.LogtoService
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.jose4j.jwk.JsonWebKeySet
 
 class LogtoAndroidClient(
     logtoConfig: LogtoConfig,
@@ -51,15 +48,12 @@ class LogtoAndroidClient(
     ) = coroutineScope.launch {
         try {
             val oidcConfiguration = getOidcConfiguration()
-            val jwks = getJsonWebKeySet()
             val tokenSet = grantTokenByAuthorizationCode(
                 oidcConfiguration.tokenEndpoint,
                 authorizationCode,
                 codeVerifier
-            ).apply {
-                calculateExpiresAt()
-                validateIdToken(logtoConfig.clientId, jwks)
-            }
+            )
+
             block(null, tokenSet)
         } catch (exception: LogtoException) {
             block(exception, null)
@@ -72,14 +66,10 @@ class LogtoAndroidClient(
     ) = coroutineScope.launch {
         try {
             val oidcConfiguration = getOidcConfiguration()
-            val jwks = getJsonWebKeySet()
             val tokenSet = grantTokenByRefreshToken(
                 oidcConfiguration.tokenEndpoint,
                 refreshToken
-            ).apply {
-                calculateExpiresAt()
-                validateIdToken(logtoConfig.clientId, jwks)
-            }
+            )
             block(null, tokenSet)
         } catch (exception: LogtoException) {
             block(exception, null)
@@ -90,31 +80,4 @@ class LogtoAndroidClient(
     internal fun setCoroutineScope(scope: CoroutineScope) {
         coroutineScope = scope
     }
-
-    internal suspend fun getOidcConfiguration(): OidcConfiguration = withContext(
-        coroutineScope.coroutineContext
-    ) {
-        oidcConfigCache?.let {
-            return@withContext it
-        }
-        val oidcConfiguration = fetchOidcConfiguration()
-        oidcConfigCache = oidcConfiguration
-        return@withContext oidcConfiguration
-    }
-
-    internal suspend fun getJsonWebKeySet(): JsonWebKeySet = withContext(
-        coroutineScope.coroutineContext
-    ) {
-        jsonWebKeySetCache?.let {
-            return@withContext it
-        }
-        val oidcConfiguration = getOidcConfiguration()
-        val fetchedJsonWebKeySet = fetchJwks(oidcConfiguration)
-        jsonWebKeySetCache = fetchedJsonWebKeySet
-        return@withContext fetchedJsonWebKeySet
-    }
-
-    private var oidcConfigCache: OidcConfiguration? = null
-
-    private var jsonWebKeySetCache: JsonWebKeySet? = null
 }

--- a/android/library/src/main/java/io/logto/client/model/TokenSet.kt
+++ b/android/library/src/main/java/io/logto/client/model/TokenSet.kt
@@ -2,7 +2,6 @@ package io.logto.client.model
 
 import io.logto.client.utils.TimeUtils
 import io.logto.client.utils.TokenUtils
-import org.jose4j.jwk.JsonWebKeySet
 
 data class TokenSet(
     val accessToken: String,
@@ -10,20 +9,9 @@ data class TokenSet(
     val idToken: String,
     val scope: String,
     val tokenType: String,
-    private val expiresIn: Long,
+    val expiresAt: Long,
 ) {
-    var expiresAt: Long = 0L
-
     fun isExpired(): Boolean = TimeUtils.nowRoundToSec() >= expiresAt
-
-    fun calculateExpiresAt() {
-        expiresAt = TimeUtils.expiresAtFromNow(expiresIn)
-    }
-
-    fun validateIdToken(
-        clientId: String,
-        jwks: JsonWebKeySet,
-    ) = TokenUtils.verifyIdToken(idToken, clientId, jwks)
 
     fun getIdTokenClaims() = TokenUtils.decodeToken(idToken)
 }

--- a/android/library/src/main/java/io/logto/client/model/TokenSetParameters.kt
+++ b/android/library/src/main/java/io/logto/client/model/TokenSetParameters.kt
@@ -1,0 +1,27 @@
+package io.logto.client.model
+
+import io.logto.client.utils.TimeUtils
+import io.logto.client.utils.TokenUtils
+import org.jose4j.jwk.JsonWebKeySet
+
+data class TokenSetParameters(
+    val accessToken: String,
+    val refreshToken: String?,
+    val idToken: String,
+    val scope: String,
+    val tokenType: String,
+    val expiresIn: Long,
+) {
+    fun verifyIdToken(clientId: String, jwks: JsonWebKeySet) {
+        TokenUtils.verifyIdToken(idToken, clientId, jwks)
+    }
+
+    fun convertTokenSet(): TokenSet = TokenSet(
+        accessToken = accessToken,
+        refreshToken = refreshToken,
+        idToken = idToken,
+        scope = scope,
+        tokenType = tokenType,
+        expiresAt = TimeUtils.expiresAtFromNow(expiresIn)
+    )
+}

--- a/android/library/src/main/java/io/logto/client/service/LogtoService.kt
+++ b/android/library/src/main/java/io/logto/client/service/LogtoService.kt
@@ -14,7 +14,7 @@ import io.logto.client.exception.LogtoException
 import io.logto.client.extensions.httpGet
 import io.logto.client.extensions.httpPost
 import io.logto.client.model.OidcConfiguration
-import io.logto.client.model.TokenSet
+import io.logto.client.model.TokenSetParameters
 import org.jose4j.jwk.JsonWebKeySet
 import org.json.JSONException
 
@@ -41,7 +41,7 @@ class LogtoService(
         redirectUri: String,
         code: String,
         codeVerifier: String,
-    ): TokenSet = httpClient.httpPost(tokenEndpoint, LogtoException.REQUEST_TOKEN_FAILED) {
+    ): TokenSetParameters = httpClient.httpPost(tokenEndpoint, LogtoException.REQUEST_TOKEN_FAILED) {
         headers {
             contentType(ContentType.Application.FormUrlEncoded)
         }
@@ -59,7 +59,7 @@ class LogtoService(
         clientId: String,
         redirectUri: String,
         refreshToken: String,
-    ): TokenSet = httpClient.httpPost(tokenEndpoint, LogtoException.REQUEST_TOKEN_FAILED) {
+    ): TokenSetParameters = httpClient.httpPost(tokenEndpoint, LogtoException.REQUEST_TOKEN_FAILED) {
         headers {
             contentType(ContentType.Application.FormUrlEncoded)
         }

--- a/android/library/src/test/java/io/logto/android/client/LogtoAndroidClientTest.kt
+++ b/android/library/src/test/java/io/logto/android/client/LogtoAndroidClientTest.kt
@@ -19,12 +19,10 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import java.util.UUID
@@ -61,46 +59,16 @@ class LogtoAndroidClientTest {
     }
 
     @Test
-    fun getOidcConfigurationAsyncShouldCallBlock() {
-        runBlockingTest {
-            doReturn(oidcConfigurationMock).`when`(logtoAndroidClientSpy).getOidcConfiguration()
-            val handleOidcConfigurationCallbackMock: HandleOidcConfigurationCallback = mock()
+    fun getOidcConfigurationAsyncShouldCallBlock() = runBlockingTest {
+        doReturn(oidcConfigurationMock).`when`(logtoAndroidClientSpy).getOidcConfiguration()
+        val handleOidcConfigurationCallbackMock: HandleOidcConfigurationCallback = mock()
 
-            logtoAndroidClientSpy.getOidcConfigurationAsync(handleOidcConfigurationCallbackMock)
-                .invokeOnCompletion { throwable ->
-                    assertThat(throwable).isNull()
-                    verify(handleOidcConfigurationCallbackMock)
-                        .invoke(eq(null), eq(oidcConfigurationMock))
-                }
-        }
-    }
-
-    @Test
-    fun getOidcConfigurationMoreThenOnceShouldJustFetchOnce() {
-        runBlockingTest {
-            doReturn(oidcConfigurationMock).`when`(logtoAndroidClientSpy)
-                .fetchOidcConfiguration()
-
-            logtoAndroidClientSpy.getOidcConfiguration()
-            logtoAndroidClientSpy.getOidcConfiguration()
-
-            verify(logtoAndroidClientSpy, times(1)).fetchOidcConfiguration()
-        }
-    }
-
-    @Test
-    fun getJsonWebKeySetMoreThenOnceShouldJustFetchOnce() {
-        runBlockingTest {
-            `when`(oidcConfigurationMock.jwksUri).thenReturn("jwksUri")
-            doReturn(oidcConfigurationMock).`when`(logtoAndroidClientSpy)
-                .fetchOidcConfiguration()
-            doReturn(jsonWebKeySetMock).`when`(logtoAndroidClientSpy).fetchJwks(anyOrNull())
-
-            logtoAndroidClientSpy.getJsonWebKeySet()
-            logtoAndroidClientSpy.getJsonWebKeySet()
-
-            verify(logtoAndroidClientSpy, times(1)).fetchJwks(anyOrNull())
-        }
+        logtoAndroidClientSpy.getOidcConfigurationAsync(handleOidcConfigurationCallbackMock)
+            .invokeOnCompletion { throwable ->
+                assertThat(throwable).isNull()
+                verify(handleOidcConfigurationCallbackMock)
+                    .invoke(eq(null), eq(oidcConfigurationMock))
+            }
     }
 
     @Test
@@ -109,7 +77,6 @@ class LogtoAndroidClientTest {
         `when`(oidcConfigurationMock.tokenEndpoint).thenReturn("tokenEndpoint")
         doReturn(oidcConfigurationMock).`when`(logtoAndroidClientSpy).getOidcConfiguration()
         doReturn(jsonWebKeySetMock).`when`(logtoAndroidClientSpy).getJsonWebKeySet()
-        doNothing().`when`(tokenSetMock).validateIdToken(anyOrNull(), anyOrNull())
         doReturn(tokenSetMock)
             .`when`(logtoAndroidClientSpy)
             .grantTokenByAuthorizationCode(anyString(), anyString(), anyString())
@@ -133,7 +100,6 @@ class LogtoAndroidClientTest {
         `when`(oidcConfigurationMock.tokenEndpoint).thenReturn("tokenEndpoint")
         doReturn(oidcConfigurationMock).`when`(logtoAndroidClientSpy).getOidcConfiguration()
         doReturn(jsonWebKeySetMock).`when`(logtoAndroidClientSpy).getJsonWebKeySet()
-        doNothing().`when`(tokenSetMock).validateIdToken(anyOrNull(), anyOrNull())
         doReturn(tokenSetMock).`when`(logtoAndroidClientSpy)
             .grantTokenByRefreshToken(anyOrNull(), anyOrNull())
         val dummyRefreshToken = UUID.randomUUID().toString()

--- a/android/library/src/test/java/io/logto/android/storage/TokenSetStorageTest.kt
+++ b/android/library/src/test/java/io/logto/android/storage/TokenSetStorageTest.kt
@@ -28,7 +28,7 @@ class TokenSetStorageTest {
         idToken = "idToken",
         scope = "offline_access openid",
         tokenType = "Bearer",
-        expiresIn = 60L
+        expiresAt = 60L
     )
 
     private val sharedPreferencesName = "io.logto.android::${logtoConfig.cacheKey}"

--- a/android/library/src/test/java/io/logto/client/LogtoClientTest.kt
+++ b/android/library/src/test/java/io/logto/client/LogtoClientTest.kt
@@ -10,12 +10,19 @@ import io.logto.client.constant.ResourceValue
 import io.logto.client.constant.ResponseType
 import io.logto.client.constant.ScopeValue
 import io.logto.client.model.OidcConfiguration
+import io.logto.client.model.TokenSet
+import io.logto.client.model.TokenSetParameters
 import io.logto.client.service.LogtoService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import org.jose4j.jwk.JsonWebKeySet
 import org.junit.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import java.util.UUID
 
@@ -82,28 +89,81 @@ class LogtoClientTest {
     }
 
     @Test
-    fun fetchOidcConfiguration() = runBlockingTest {
+    fun getOidcConfiguration() = runBlockingTest {
         val logtoServiceMock: LogtoService = mock()
+        val oidcConfigurationMock: OidcConfiguration = mock()
+        doReturn(oidcConfigurationMock)
+            .`when`(logtoServiceMock).fetchOidcConfiguration(eq(testLogtoConfig.domain))
         val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
 
-        logtoClient.fetchOidcConfiguration()
+        val oidcConfiguration = logtoClient.getOidcConfiguration()
 
-        verify(logtoServiceMock).fetchOidcConfiguration(eq(testLogtoConfig.domain))
+        assertThat(oidcConfiguration).isEqualTo(oidcConfigurationMock)
+    }
+
+    @Test
+    fun getOidcConfigurationMoreThenOnceShouldJustFetchOnce() = runBlockingTest {
+        val logtoServiceMock: LogtoService = mock()
+        val oidcConfigurationMock: OidcConfiguration = mock()
+        doReturn(oidcConfigurationMock)
+            .`when`(logtoServiceMock).fetchOidcConfiguration(eq(testLogtoConfig.domain))
+        val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
+
+        logtoClient.getOidcConfiguration()
+        logtoClient.getOidcConfiguration()
+
+        verify(logtoServiceMock, times(1)).fetchOidcConfiguration(eq(testLogtoConfig.domain))
+    }
+
+    @Test
+    fun getOidcConfigurationMoreThenOnceShouldBeTheSameValue() = runBlockingTest {
+        val logtoServiceMock: LogtoService = mock()
+        val oidcConfigurationMock: OidcConfiguration = mock()
+        doReturn(oidcConfigurationMock)
+            .`when`(logtoServiceMock).fetchOidcConfiguration(eq(testLogtoConfig.domain))
+        val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
+
+        val oidcConfiguration1 = logtoClient.getOidcConfiguration()
+        val oidcConfiguration2 = logtoClient.getOidcConfiguration()
+
+        assertThat(oidcConfiguration1).isEqualTo(oidcConfigurationMock)
+        assertThat(oidcConfiguration2).isEqualTo(oidcConfigurationMock)
+        assertThat(oidcConfiguration1).isEqualTo(oidcConfiguration2)
     }
 
     @Test
     fun grantTokenByAuthorizationCode() = runBlockingTest {
+        val logtoServiceMock: LogtoService = mock()
+        doReturn(testOidcConfiguration).`when`(logtoServiceMock).fetchOidcConfiguration(anyOrNull())
+
+        val jwksMock: JsonWebKeySet = mock()
+        doReturn(jwksMock).`when`(logtoServiceMock).fetchJwks(anyOrNull())
+
+        val tokenSetParametersMock: TokenSetParameters = mock()
+        doNothing().`when`(tokenSetParametersMock).verifyIdToken(anyOrNull(), anyOrNull())
+        doReturn(tokenSetParametersMock).`when`(logtoServiceMock).grantTokenByAuthorizationCode(
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull()
+        )
+
+        val tokenSetMock: TokenSet = mock()
+        doReturn(tokenSetMock).`when`(tokenSetParametersMock).convertTokenSet()
+
         val authorizationCode = UUID.randomUUID().toString()
         val codeVerifier = UUID.randomUUID().toString()
-        val logtoServiceMock: LogtoService = mock()
+
         val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
 
-        logtoClient.grantTokenByAuthorizationCode(
+        val tokenSet = logtoClient.grantTokenByAuthorizationCode(
             testOidcConfiguration.tokenEndpoint,
             authorizationCode,
             codeVerifier
         )
 
+        assertThat(tokenSet).isEqualTo(tokenSetMock)
         verify(logtoServiceMock).grantTokenByAuthorizationCode(
             tokenEndpoint = eq(testOidcConfiguration.tokenEndpoint),
             clientId = eq(testLogtoConfig.clientId),
@@ -115,15 +175,34 @@ class LogtoClientTest {
 
     @Test
     fun grantTokenByRefreshToken() = runBlockingTest {
-        val refreshToken = UUID.randomUUID().toString()
         val logtoServiceMock: LogtoService = mock()
+        doReturn(testOidcConfiguration).`when`(logtoServiceMock).fetchOidcConfiguration(anyOrNull())
+
+        val jwksMock: JsonWebKeySet = mock()
+        doReturn(jwksMock).`when`(logtoServiceMock).fetchJwks(anyOrNull())
+
+        val tokenSetParametersMock: TokenSetParameters = mock()
+        doNothing().`when`(tokenSetParametersMock).verifyIdToken(anyOrNull(), anyOrNull())
+        doReturn(tokenSetParametersMock).`when`(logtoServiceMock).grantTokenByRefreshToken(
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull()
+        )
+
+        val tokenSetMock: TokenSet = mock()
+        doReturn(tokenSetMock).`when`(tokenSetParametersMock).convertTokenSet()
+
+        val refreshToken = UUID.randomUUID().toString()
+
         val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
 
-        logtoClient.grantTokenByRefreshToken(
+        val tokenSet = logtoClient.grantTokenByRefreshToken(
             testOidcConfiguration.tokenEndpoint,
             refreshToken
         )
 
+        assertThat(tokenSet).isEqualTo(tokenSetMock)
         verify(logtoServiceMock).grantTokenByRefreshToken(
             tokenEndpoint = eq(testOidcConfiguration.tokenEndpoint),
             clientId = eq(testLogtoConfig.clientId),
@@ -133,12 +212,56 @@ class LogtoClientTest {
     }
 
     @Test
-    fun fetchJwks() = runBlockingTest {
+    fun getJsonWebKeySet() = runBlockingTest {
+        val jwksMock: JsonWebKeySet = mock()
+        val oidcConfigurationMock: OidcConfiguration = mock()
         val logtoServiceMock: LogtoService = mock()
+        doReturn(oidcConfigurationMock)
+            .`when`(logtoServiceMock).fetchOidcConfiguration(anyOrNull())
+        doReturn(jwksMock)
+            .`when`(logtoServiceMock).fetchJwks(anyOrNull())
         val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
 
-        logtoClient.fetchJwks(testOidcConfiguration)
+        val jwks = logtoClient.getJsonWebKeySet()
 
-        verify(logtoServiceMock).fetchJwks(eq(testOidcConfiguration.jwksUri))
+        assertThat(jwks).isEqualTo(jwksMock)
+    }
+
+    @Test
+    fun getJsonWebKeySetMoreThenOnceShouldJustFetchOnce() = runBlockingTest {
+        val jwksMock: JsonWebKeySet = mock()
+        val oidcConfigurationMock: OidcConfiguration = mock()
+        val logtoServiceMock: LogtoService = mock()
+        doReturn(oidcConfigurationMock)
+            .`when`(logtoServiceMock).fetchOidcConfiguration(anyOrNull())
+        doReturn(jwksMock)
+            .`when`(logtoServiceMock).fetchJwks(anyOrNull())
+
+        val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
+
+        logtoClient.getJsonWebKeySet()
+        logtoClient.getJsonWebKeySet()
+
+        verify(logtoServiceMock, times(1)).fetchJwks(anyOrNull())
+    }
+
+    @Test
+    fun getJsonWebKeySetMoreThenOnceShouldBeTheSameValue() = runBlockingTest {
+        val jwksMock: JsonWebKeySet = mock()
+        val oidcConfigurationMock: OidcConfiguration = mock()
+        val logtoServiceMock: LogtoService = mock()
+        doReturn(oidcConfigurationMock)
+            .`when`(logtoServiceMock).fetchOidcConfiguration(anyOrNull())
+        doReturn(jwksMock)
+            .`when`(logtoServiceMock).fetchJwks(anyOrNull())
+
+        val logtoClient = LogtoClient(testLogtoConfig, logtoServiceMock)
+
+        val jwks1 = logtoClient.getJsonWebKeySet()
+        val jwks2 = logtoClient.getJsonWebKeySet()
+
+        assertThat(jwks1).isEqualTo(jwksMock)
+        assertThat(jwks2).isEqualTo(jwksMock)
+        assertThat(jwks1).isEqualTo(jwks2)
     }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
* refactor: move token validation logic to `logtoClient`


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* [refactor: move token validation logic to `logtoClient` (LOG-329)](https://linear.app/silverhand/issue/LOG-329/refactor-move-token-validation-logic-to-logtoclient)


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT
