### PR TITLE
fix: should start an customTab in a brand new device on sign in

### DIFF
--- a/android/library/src/main/java/io/logto/android/auth/AuthManager.kt
+++ b/android/library/src/main/java/io/logto/android/auth/AuthManager.kt
@@ -6,6 +6,9 @@ import android.net.Uri
 object AuthManager {
     internal var currentFlow: IFlow? = null
 
+    val isInFlowProcess: Boolean
+        get() = currentFlow != null
+
     fun start(context: Context, flow: IFlow) {
         currentFlow = flow
         flow.start(context)

--- a/android/library/src/main/java/io/logto/android/auth/activity/AuthorizationActivity.kt
+++ b/android/library/src/main/java/io/logto/android/auth/activity/AuthorizationActivity.kt
@@ -86,7 +86,6 @@ class AuthorizationActivity : AppCompatActivity() {
 
     private fun startFlowWithCustomTabs(endpoint: String) {
         val customTabsIntent = CustomTabsIntent.Builder().build()
-        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
         customTabsIntent.launchUrl(this, Uri.parse(endpoint))
     }
 

--- a/android/library/src/main/java/io/logto/android/auth/activity/RedirectUriActivity.kt
+++ b/android/library/src/main/java/io/logto/android/auth/activity/RedirectUriActivity.kt
@@ -7,9 +7,12 @@ import io.logto.android.auth.AuthManager
 class RedirectUriActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        intent.data?.let {
-            startActivity(AuthorizationActivity.createHandleCompleteIntent(this))
-            AuthManager.handleRedirectUri(it)
-        } ?: finish()
+        if (AuthManager.isInFlowProcess) {
+            intent.data?.let {
+                startActivity(AuthorizationActivity.createHandleCompleteIntent(this))
+                AuthManager.handleRedirectUri(it)
+            }
+        }
+        finish()
     }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
In a brand new device which haven't been launched chrome will cause our sdk start an custom tab and flush out immediately. Because we need to agree the TOS of chrome.

So, we should not launch our custom tab with flag [FLAG_ACTIVITY_SINGLE_TOP](https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_SINGLE_TOP) which will lead to launch tab before our agreement to chorme. this make our tab flush out.

And we don't need to launch custom tab with flag [FLAG_ACTIVITY_CLEAR_TOP](https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_CLEAR_TOP) for we launch tabs above our application every time.

If we start chrome custom tab with the progress of agreement of chrome's TOS. we will have multi activities in the background. we may navigate to our app without sign in.

So we have to handle this situation. we close the `RedirectUriActivity` when we lose our flow context.


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* [Fix: should start an customTab in a brand new device on sign in (LOG-336)](https://linear.app/silverhand/issue/LOG-336/fix-should-start-an-customtab-in-a-brand-new-device-on-sign-in)


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Will launch with TOS of chrom
![launch with tos](https://user-images.githubusercontent.com/10806653/143195307-0128d7ff-4e1c-4bea-afff-ce82856d770f.gif)
