### PR TITLE
feat(android): add state to signInUrl to prevent csrf attacking

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,7 @@ buildscript {
         robolectricVersion = '4.6.1'
         mockitoVersion = '4.0.0'
         coroutinesTestVersion = '1.5.2'
+        mockkVersion = '1.12.1'
     }
 
     repositories {

--- a/android/library/build.gradle
+++ b/android/library/build.gradle
@@ -79,4 +79,5 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:$rootProject.mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$rootProject.mockitoVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.coroutinesTestVersion"
+    testImplementation "io.mockk:mockk:$rootProject.mockkVersion"
 }

--- a/android/library/src/main/java/io/logto/client/LogtoClient.kt
+++ b/android/library/src/main/java/io/logto/client/LogtoClient.kt
@@ -19,11 +19,13 @@ open class LogtoClient(
     fun getSignInUrl(
         authorizationEndpoint: String,
         codeChallenge: String,
+        state: String,
     ): String {
         val urlBuilder = URLBuilder(authorizationEndpoint).apply {
             parameters.append(QueryKey.CLIENT_ID, logtoConfig.clientId)
             parameters.append(QueryKey.CODE_CHALLENGE, codeChallenge)
             parameters.append(QueryKey.CODE_CHALLENGE_METHOD, CodeChallengeMethod.S256)
+            parameters.append(QueryKey.STATE, state)
             parameters.append(QueryKey.PROMPT, PromptValue.CONSENT)
             parameters.append(QueryKey.REDIRECT_URI, logtoConfig.redirectUri)
             parameters.append(QueryKey.RESPONSE_TYPE, ResponseType.CODE)

--- a/android/library/src/main/java/io/logto/client/constant/QueryKey.kt
+++ b/android/library/src/main/java/io/logto/client/constant/QueryKey.kt
@@ -6,6 +6,7 @@ object QueryKey {
     const val CODE_CHALLENGE = "code_challenge"
     const val CODE_CHALLENGE_METHOD = "code_challenge_method"
     const val CODE_VERIFIER = "code_verifier"
+    const val STATE = "state"
     const val ERROR = "error"
     const val ERROR_DESCRIPTION = "error_description"
     const val GRANT_TYPE = "grant_type"

--- a/android/library/src/main/java/io/logto/client/exception/LogtoException.kt
+++ b/android/library/src/main/java/io/logto/client/exception/LogtoException.kt
@@ -12,6 +12,8 @@ class LogtoException(
         const val INVALID_REDIRECT_URI = "Invalid redirect uri"
         const val EMPTY_REDIRECT_URI = "Empty redirect uri"
         const val MISSING_AUTHORIZATION_CODE = "Missing authorization code"
+        const val MISSING_STATE = "Missing state"
+        const val UNKNOWN_STATE = "Unknown state"
         const val SIGN_OUT_FAILED = "Sign out failed"
         const val INVALID_JWT = "Invalid jwt"
         const val REQUEST_OIDC_CONFIGURATION_FAILED = "Request oidc configuration failed"

--- a/android/library/src/main/java/io/logto/client/utils/GenerateUtils.kt
+++ b/android/library/src/main/java/io/logto/client/utils/GenerateUtils.kt
@@ -7,19 +7,14 @@ import java.io.UnsupportedEncodingException
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 
-object PkceUtils {
+object GenerateUtils {
     private const val CODE_VERIFIER_ALPHABET =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
-    private const val CODE_VERIFIER_LEN = 64
     private const val DEFAULT_ALGORITHM = "SHA-256"
+    private const val DEFAULT_RANDOM_STRING_LENGTH = 64
 
     fun generateCodeVerifier(): String {
-        val randomString = NanoIdUtils.randomNanoId(
-            NanoIdUtils.DEFAULT_NUMBER_GENERATOR,
-            CODE_VERIFIER_ALPHABET.toCharArray(),
-            CODE_VERIFIER_LEN
-        )
-        return Base64Url.encode(randomString.toByteArray())
+        return generateRandomString()
     }
 
     fun generateCodeChallenge(codeVerifier: String): String {
@@ -36,5 +31,18 @@ object PkceUtils {
         } catch (exception: UnsupportedEncodingException) {
             throw LogtoException(LogtoException.CODE_CHALLENGE_ENCODED_FAILED, exception)
         }
+    }
+
+    fun generateState(): String {
+        return generateRandomString()
+    }
+
+    private fun generateRandomString(stringLength: Int = DEFAULT_RANDOM_STRING_LENGTH): String {
+        val randomString = NanoIdUtils.randomNanoId(
+            NanoIdUtils.DEFAULT_NUMBER_GENERATOR,
+            CODE_VERIFIER_ALPHABET.toCharArray(),
+            stringLength
+        )
+        return Base64Url.encode(randomString.toByteArray())
     }
 }

--- a/android/library/src/test/java/io/logto/client/LogtoClientTest.kt
+++ b/android/library/src/test/java/io/logto/client/LogtoClientTest.kt
@@ -50,10 +50,12 @@ class LogtoClientTest {
     fun getSignInUrl() {
         val dummyLogtoService: LogtoService = mock()
         val codeChallenge = UUID.randomUUID().toString()
+        val state = UUID.randomUUID().toString()
         val logtoClient = LogtoClient(testLogtoConfig, dummyLogtoService)
         val signInUrlStr = logtoClient.getSignInUrl(
             testOidcConfiguration.authorizationEndpoint,
-            codeChallenge
+            codeChallenge,
+            state,
         )
         Url(signInUrlStr).apply {
             assertThat(protocol.name).isEqualTo("https")
@@ -62,6 +64,7 @@ class LogtoClientTest {
             assertThat(parameters[QueryKey.CLIENT_ID]).isEqualTo(testLogtoConfig.clientId)
             assertThat(parameters[QueryKey.CODE_CHALLENGE]).isEqualTo(codeChallenge)
             assertThat(parameters[QueryKey.CODE_CHALLENGE_METHOD]).isEqualTo(CodeChallengeMethod.S256)
+            assertThat(parameters[QueryKey.STATE]).isEqualTo(state)
             assertThat(parameters[QueryKey.PROMPT]).isEqualTo(PromptValue.CONSENT)
             assertThat(parameters[QueryKey.RESPONSE_TYPE]).isEqualTo(ResponseType.CODE)
             assertThat(parameters[QueryKey.SCOPE]).isEqualTo(testLogtoConfig.scope)

--- a/android/library/src/test/java/io/logto/client/utils/GenerateUtilsTest.kt
+++ b/android/library/src/test/java/io/logto/client/utils/GenerateUtilsTest.kt
@@ -4,41 +4,41 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import kotlin.math.ceil
 
-class PkceUtilsTest {
+class GenerateUtilsTest {
     @Test
     fun generateCodeVerifierShouldBeFixedLength() {
-        val codeVerifier = PkceUtils.generateCodeVerifier()
+        val codeVerifier = GenerateUtils.generateCodeVerifier()
         assertThat(codeVerifier.length).isEqualTo(ceil(64 * 1.34).toInt())
     }
 
     @Test
     fun generateCodeVerifierShouldBeRandomString() {
-        val code1 = PkceUtils.generateCodeVerifier()
-        val code2 = PkceUtils.generateCodeVerifier()
+        val code1 = GenerateUtils.generateCodeVerifier()
+        val code2 = GenerateUtils.generateCodeVerifier()
         assertThat(code1).isNotEqualTo(code2)
     }
 
     @Test
     fun generateCodeChallengeShouldBeFixedLength() {
-        val codeVerifier = PkceUtils.generateCodeVerifier()
-        val codeChallenge = PkceUtils.generateCodeChallenge(codeVerifier)
+        val codeVerifier = GenerateUtils.generateCodeVerifier()
+        val codeChallenge = GenerateUtils.generateCodeChallenge(codeVerifier)
         assertThat(codeChallenge.length).isEqualTo(ceil(32 * 1.34).toInt())
     }
 
     @Test
     fun generateCodeChallengeShouldBeDifferentWithDifferentCodeVerifiers() {
-        val code1 = PkceUtils.generateCodeVerifier()
-        val codeChallenge1 = PkceUtils.generateCodeChallenge(code1)
+        val code1 = GenerateUtils.generateCodeVerifier()
+        val codeChallenge1 = GenerateUtils.generateCodeChallenge(code1)
 
-        val code2 = PkceUtils.generateCodeVerifier()
-        val codeChallenge2 = PkceUtils.generateCodeChallenge(code2)
+        val code2 = GenerateUtils.generateCodeVerifier()
+        val codeChallenge2 = GenerateUtils.generateCodeChallenge(code2)
 
         assertThat(codeChallenge1).isNotEqualTo(codeChallenge2)
     }
 
     @Test
     fun generateCodeChallengeWithSpecificCodeShouldBeTheSame() {
-        val code = PkceUtils.generateCodeVerifier()
-        assertThat(PkceUtils.generateCodeChallenge(code)).isEqualTo(PkceUtils.generateCodeChallenge(code))
+        val code = GenerateUtils.generateCodeVerifier()
+        assertThat(GenerateUtils.generateCodeChallenge(code)).isEqualTo(GenerateUtils.generateCodeChallenge(code))
     }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- feat(android): add state to signInUrl to prevent csrf attacking
    - Related Notion doc : https://www.notion.so/silverhand/OAuth-2-0-Security-b7b1f43d5c784b599c084d3ff356525c
    - Related PR : https://github.com/logto-io/js/pull/94
- refactor(android): update BrowserSignInFlowTest using MockK
    - Reference : https://mockk.io/

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- Pass all existing tests

- New cases in BrowserSignInFlowTest

- Manual Android client tests

    - Succeeded to check `state` value
    ![image](https://user-images.githubusercontent.com/10594507/143377092-6018cd29-71c4-46f5-bcaa-fc78c2b8b2e7.png)

    - Login successfully
    ![image](https://user-images.githubusercontent.com/10594507/143377230-93de7e1c-aae9-4b51-a21c-a181359155d6.png)
