### PR TITLE
Refactor: replace `Mockito` with `Mockk` in unit tests

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,6 @@ buildscript {
         androidXTestCoreVersion = '1.4.0'
         truthVersion = '1.1.3'
         robolectricVersion = '4.6.1'
-        mockitoVersion = '4.0.0'
         coroutinesTestVersion = '1.5.2'
         mockkVersion = '1.12.1'
     }

--- a/android/library/build.gradle
+++ b/android/library/build.gradle
@@ -75,9 +75,6 @@ dependencies {
     testImplementation "androidx.test:core:$rootProject.androidXTestCoreVersion"
     testImplementation "com.google.truth:truth:$rootProject.truthVersion"
     testImplementation "org.robolectric:robolectric:$rootProject.robolectricVersion"
-    testImplementation "org.mockito:mockito-core:$rootProject.mockitoVersion"
-    testImplementation "org.mockito:mockito-inline:$rootProject.mockitoVersion"
-    testImplementation "org.mockito.kotlin:mockito-kotlin:$rootProject.mockitoVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.coroutinesTestVersion"
     testImplementation "io.mockk:mockk:$rootProject.mockkVersion"
 }

--- a/android/library/src/test/java/io/logto/android/auth/AuthManagerTest.kt
+++ b/android/library/src/test/java/io/logto/android/auth/AuthManagerTest.kt
@@ -4,18 +4,29 @@ import android.app.Application
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verify
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class AuthManagerTest {
     private val context = ApplicationProvider.getApplicationContext<Application>()
-    private val testFlow = mock(IFlow::class.java)
-    private val testUriData = mock(Uri::class.java)
+
+    @RelaxedMockK
+    private lateinit var testFlow: IFlow
+
+    @RelaxedMockK
+    private lateinit var testUriData: Uri
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
 
     @After
     fun tearDown() {
@@ -25,29 +36,30 @@ class AuthManagerTest {
     @Test
     fun authManagerOnStart() {
         AuthManager.start(context, testFlow)
+
         assertThat(AuthManager.currentFlow).isEqualTo(testFlow)
-        verify(testFlow).start(context)
+        verify { testFlow.start(context) }
 
         AuthManager.handleRedirectUri(testUriData)
-        verify(testFlow).handleRedirectUri(testUriData)
+
+        verify { testFlow.handleRedirectUri(testUriData) }
 
         AuthManager.reset()
+
         assertThat(AuthManager.currentFlow).isNull()
     }
 
     @Test
     fun authManagerHandleRedirectUri() {
         AuthManager.start(context, testFlow)
-
         AuthManager.handleRedirectUri(testUriData)
 
-        verify(testFlow).handleRedirectUri(testUriData)
+        verify { testFlow.handleRedirectUri(testUriData) }
     }
 
     @Test
     fun authManagerOnReset() {
         AuthManager.start(context, testFlow)
-
         AuthManager.reset()
 
         assertThat(AuthManager.currentFlow).isNull()
@@ -56,10 +68,9 @@ class AuthManagerTest {
     @Test
     fun authManagerHandleUserCanceled() {
         AuthManager.start(context, testFlow)
-
         AuthManager.handleUserCanceled()
 
-        verify(testFlow).handleUserCanceled()
+        verify { testFlow.handleUserCanceled() }
         assertThat(AuthManager.currentFlow).isNull()
     }
 }

--- a/android/library/src/test/java/io/logto/android/auth/browser/BrowserSignInFlowTest.kt
+++ b/android/library/src/test/java/io/logto/android/auth/browser/BrowserSignInFlowTest.kt
@@ -61,9 +61,9 @@ class BrowserSignInFlowTest {
 
     private val state = "state1"
 
-    private val logtoExceptionMutableList = mutableListOf<LogtoException?>()
+    private val logtoExceptionCaptureList = mutableListOf<LogtoException?>()
 
-    private val tokenSetMutableList = mutableListOf<TokenSet?>()
+    private val tokenSetCaptureList = mutableListOf<TokenSet?>()
 
     @Before
     fun setUp() {
@@ -122,8 +122,8 @@ class BrowserSignInFlowTest {
         val activity: Activity = spyk(Robolectric.buildActivity(Activity::class.java).get())
         browserSignInFlow.start(activity)
 
-        verify { onCompleteMock(mockLogtoException, captureNullable(tokenSetMutableList)) }
-        assertThat(tokenSetMutableList.last()).isNull()
+        verify { onCompleteMock(mockLogtoException, captureNullable(tokenSetCaptureList)) }
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -133,14 +133,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: $EMPTY_REDIRECT_URI")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -154,14 +154,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: mocked sign in error description")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -174,14 +174,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: mocked sign in error")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -192,14 +192,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: $INVALID_REDIRECT_URI")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -214,14 +214,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: $MISSING_STATE")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -237,14 +237,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: $UNKNOWN_STATE")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -259,14 +259,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: $MISSING_AUTHORIZATION_CODE")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -282,14 +282,14 @@ class BrowserSignInFlowTest {
 
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last())
+        assertThat(logtoExceptionCaptureList.last())
             .hasMessageThat()
             .isEqualTo("$SIGN_IN_FAILED: $MISSING_AUTHORIZATION_CODE")
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -313,8 +313,8 @@ class BrowserSignInFlowTest {
         )
         browserSignInFlow.handleRedirectUri(validUri)
 
-        verify { onCompleteMock.invoke(captureNullable(logtoExceptionMutableList), tokenSet) }
-        assertThat(logtoExceptionMutableList.last()).isNull()
+        verify { onCompleteMock.invoke(captureNullable(logtoExceptionCaptureList), tokenSet) }
+        assertThat(logtoExceptionCaptureList.last()).isNull()
     }
 
     @Test
@@ -337,8 +337,8 @@ class BrowserSignInFlowTest {
         )
         browserSignInFlow.handleRedirectUri(validUri)
 
-        verify { onCompleteMock.invoke(mockLogtoException, captureNullable(tokenSetMutableList)) }
-        assertThat(tokenSetMutableList.last()).isNull()
+        verify { onCompleteMock.invoke(mockLogtoException, captureNullable(tokenSetCaptureList)) }
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 
     @Test
@@ -346,11 +346,11 @@ class BrowserSignInFlowTest {
         browserSignInFlow.handleUserCanceled()
         verify {
             onCompleteMock.invoke(
-                captureNullable(logtoExceptionMutableList),
-                captureNullable(tokenSetMutableList)
+                captureNullable(logtoExceptionCaptureList),
+                captureNullable(tokenSetCaptureList)
             )
         }
-        assertThat(logtoExceptionMutableList.last()).hasMessageThat().isEqualTo(USER_CANCELED)
-        assertThat(tokenSetMutableList.last()).isNull()
+        assertThat(logtoExceptionCaptureList.last()).hasMessageThat().isEqualTo(USER_CANCELED)
+        assertThat(tokenSetCaptureList.last()).isNull()
     }
 }

--- a/android/library/src/test/java/io/logto/android/utils/UtilsTest.kt
+++ b/android/library/src/test/java/io/logto/android/utils/UtilsTest.kt
@@ -43,9 +43,9 @@ class UtilsTest {
             QueryKey.ERROR_DESCRIPTION to exceptionMsg
         ))
 
-        val expectedExcpetionMsg = Utils.validateRedirectUri(uriWithErrorDesc, dummyBaseUri)
+        val expectedExceptionMsg = Utils.validateRedirectUri(uriWithErrorDesc, dummyBaseUri)
 
-        assertThat(expectedExcpetionMsg).isEqualTo(exceptionMsg)
+        assertThat(expectedExceptionMsg).isEqualTo(exceptionMsg)
     }
 
     @Test
@@ -56,9 +56,9 @@ class UtilsTest {
             QueryKey.ERROR to exceptionMsg
         ))
 
-        val expectedExcpetionMsg = Utils.validateRedirectUri(uriWithError, dummyBaseUri)
+        val expectedExceptionMsg = Utils.validateRedirectUri(uriWithError, dummyBaseUri)
 
-        assertThat(expectedExcpetionMsg).isEqualTo(exceptionMsg)
+        assertThat(expectedExceptionMsg).isEqualTo(exceptionMsg)
     }
 
     @Test
@@ -67,9 +67,9 @@ class UtilsTest {
         val uri = Uri.parse(baseUri)
         val anotherBaseUri = UUID.randomUUID().toString()
 
-        val expectedExcpetionMsg = Utils.validateRedirectUri(uri, anotherBaseUri)
+        val expectedExceptionMsg = Utils.validateRedirectUri(uri, anotherBaseUri)
 
-        assertThat(expectedExcpetionMsg).isEqualTo(LogtoException.INVALID_REDIRECT_URI)
+        assertThat(expectedExceptionMsg).isEqualTo(LogtoException.INVALID_REDIRECT_URI)
     }
 
     @Test


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- Refactor: replace `Mockito` with `Mockk` in unit tests
    - MockK supports mocking static methods and objects but Mockito cannot.
- References:
    - Official homepage : https://mockk.io/
    - [MockK：一款強大的 Kotlin Mocking Library (Part 1 / 4)](https://medium.com/joe-tsai/mockk-%E4%B8%80%E6%AC%BE%E5%BC%B7%E5%A4%A7%E7%9A%84-kotlin-mocking-library-part-1-4-39a85e42b8)
    - [MockK：一款強大的 Kotlin Mocking Library (Part 2 / 4)](https://medium.com/joe-tsai/mockk-%E4%B8%80%E6%AC%BE%E5%BC%B7%E5%A4%A7%E7%9A%84-kotlin-mocking-library-part-2-4-4be059331110)
    - [MockK：一款強大的 Kotlin Mocking Library (Part 3 / 4)](https://medium.com/joe-tsai/mockk-%E4%B8%80%E6%AC%BE%E5%BC%B7%E5%A4%A7%E7%9A%84-kotlin-mocking-library-part-3-4-79b40fb73964)
    - [MockK：一款強大的 Kotlin Mocking Library (Part 4 / 4)](https://medium.com/joe-tsai/mockk-%E4%B8%80%E6%AC%BE%E5%BC%B7%E5%A4%A7%E7%9A%84-kotlin-mocking-library-part-4-4-f82443848a3a)

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- Pass all existing unit tests after refactoring.