### PR TITLE
chore: disable unnecessary MockK DEBUG logs in test

### DIFF
--- a/android/library/src/test/resources/logback.xml
+++ b/android/library/src/test/resources/logback.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Purpose: Disable the unnecessary MockK DEBUG logs in the test results. -->
+    <root level="INFO" />
+</configuration>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
- Disable the unnecessary MockK DEBUG logs in the test
    - Reference: [Turn off logging - mockk/mockk](https://github.com/mockk/mockk/issues/37)

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests

Before: 
![image](https://user-images.githubusercontent.com/10594507/144957459-6a9a8502-4363-460e-a9ba-382043b324b9.png)

After:
![image](https://user-images.githubusercontent.com/10594507/144957484-877ea2aa-dff5-4684-85bc-b414605eddbf.png)

