### PR TITLE
feat(core): code format detecting

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -34,6 +34,9 @@ tasks {
 }
 
 dependencies {
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.19.0")
+    detekt("io.gitlab.arturbosch.detekt:detekt-formatting:1.19.0")
+
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.5.31"))
     implementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.3"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Detekt is a static code analyzer, but it doesn't support code formatting by default, we should add the `detekt-formatting` dependency if we want to detect code format.
Reference: https://detekt.github.io/detekt/#adding-more-rule-sets

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-978

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
None.

@logto-io/eng 