### PR TITLE
chore(core): disable detekt reports

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -33,6 +33,15 @@ tasks {
     }
 }
 
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    reports {
+        xml.required.set(false)
+        html.required.set(false)
+        txt.required.set(false)
+        sarif.required.set(false)
+    }
+}
+
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.5.31"))
     implementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.3"))


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
detekt will generate reports under the build folder by default.
add config for detekt to disable reports.

![image](https://user-images.githubusercontent.com/10806653/150052446-96cdfc0e-2757-4ad5-8f02-bde85cd6d8d1.png)


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
None.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10806653/150053343-03abcf42-deff-43c9-8cd9-cecd69805053.png)

@logto-io/eng 
