### PR TITLE
refactor(core): use `login` as the value of the `prompt` in generate sign in uri

### DIFF
--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/Core.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/Core.kt
@@ -38,7 +38,7 @@ object Core {
             addQueryParameter(QueryKey.CODE_CHALLENGE_METHOD, CodeChallengeMethod.S256)
             addQueryParameter(QueryKey.STATE, state)
             addQueryParameter(QueryKey.REDIRECT_URI, redirectUri)
-            addQueryParameter(QueryKey.PROMPT, PromptValue.CONSENT)
+            addQueryParameter(QueryKey.PROMPT, PromptValue.LOGIN)
             addQueryParameter(QueryKey.RESPONSE_TYPE, ResponseType.CODE)
             addQueryParameter(QueryKey.SCOPE, ScopeUtils.withReservedScopes(scopes).joinToString(" "))
             resources?.let { for (value in it) { addQueryParameter(QueryKey.RESOURCE, value) } }

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/PromptValue.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/PromptValue.kt
@@ -1,5 +1,5 @@
 package io.logto.sdk.core.constant
 
 object PromptValue {
-    const val CONSENT = "consent"
+    const val LOGIN = "login"
 }

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreTest.kt
@@ -1,8 +1,7 @@
 package io.logto.sdk.core
 
 import com.google.common.truth.Truth.assertThat
-import io.logto.sdk.core.constant.QueryKey
-import io.logto.sdk.core.constant.ReservedScope
+import io.logto.sdk.core.constant.*
 import io.logto.sdk.core.exception.UriConstructionException
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert
@@ -36,9 +35,12 @@ class CoreTest {
             assertThat(host).isEqualTo(testAuthorizationEndpoint.toHttpUrl().host)
             assertThat(pathSegments).isEqualTo(testAuthorizationEndpoint.toHttpUrl().pathSegments)
             assertThat(queryParameter(QueryKey.CLIENT_ID)).isEqualTo(testClientId)
-            assertThat(queryParameter(QueryKey.REDIRECT_URI)).isEqualTo(testRedirectUri)
             assertThat(queryParameter(QueryKey.CODE_CHALLENGE)).isEqualTo(testCodeChallenge)
+            assertThat(queryParameter(QueryKey.CODE_CHALLENGE_METHOD)).isEqualTo(CodeChallengeMethod.S256)
             assertThat(queryParameter(QueryKey.STATE)).isEqualTo(testState)
+            assertThat(queryParameter(QueryKey.REDIRECT_URI)).isEqualTo(testRedirectUri)
+            assertThat(queryParameter(QueryKey.PROMPT)).isEqualTo(PromptValue.LOGIN)
+            assertThat(queryParameter(QueryKey.RESPONSE_TYPE)).isEqualTo(ResponseType.CODE)
             assertThat(queryParameter(QueryKey.SCOPE)).apply {
                 contains(ReservedScope.OPENID)
                 contains(ReservedScope.OFFLINE_ACCESS)


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
refactor(core): use `login` as the value of the `prompt` in generate sign in uri

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2149

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT