### PR TITLE
test(core): add missing tests for core

### DIFF
--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreFetchTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreFetchTest.kt
@@ -171,7 +171,7 @@ class CoreFetchTest {
             redirectUri = "https://logto.dev/callback",
             codeVerifier = "codeVerifier",
             code = "code",
-            resource = null
+            resource = "resource",
         ) { throwable, response ->
             throwableReceiver = throwable
             responseReceiver = response
@@ -216,8 +216,8 @@ class CoreFetchTest {
             tokenEndpoint = "${mockWebServer.url("/token:bad")}",
             clientId = "clientId",
             refreshToken = "refreshToken",
-            resource = null,
-            scopes = null
+            resource = "resource",
+            scopes = listOf("scope1", "scope2"),
         ) { throwable, response ->
             throwableReceiver = throwable
             responseReceiver = response

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/constant/ConstantTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/constant/ConstantTest.kt
@@ -1,0 +1,17 @@
+package io.logto.sdk.core.constant
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ConstantTest {
+    @Test
+    fun `all constants should not be null`() {
+        assertThat(ClaimName).isNotNull()
+        assertThat(CodeChallengeMethod).isNotNull()
+        assertThat(GrantType).isNotNull()
+        assertThat(PromptValue).isNotNull()
+        assertThat(QueryKey).isNotNull()
+        assertThat(ReservedScope).isNotNull()
+        assertThat(ResponseType).isNotNull()
+    }
+}

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/extension/JwtClaimsExtKtTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/extension/JwtClaimsExtKtTest.kt
@@ -1,0 +1,40 @@
+package io.logto.sdk.core.extension
+
+import com.google.common.truth.Truth.assertThat
+import io.logto.sdk.core.constant.ClaimName
+import io.logto.sdk.core.type.IdTokenClaims
+import org.jose4j.jwt.JwtClaims
+import org.jose4j.jwt.NumericDate
+import org.junit.Test
+
+class JwtClaimsExtKtTest {
+    @Test
+    fun toIdTokenClaims() {
+        val testIssuer = "testIssuer"
+        val testSubject = "testSubject"
+        val testAudience = listOf("testAudience")
+        val testExp = NumericDate.fromSeconds(0L)
+        val testIssueAt = NumericDate.fromSeconds(0L)
+        val testAtHash = "testAtHash"
+
+        val idTokenClaims = IdTokenClaims(
+            iss = testIssuer,
+            sub = testSubject,
+            aud = testAudience[0],
+            exp = testExp.value,
+            iat = testIssueAt.value,
+            atHash = testAtHash
+        )
+
+        val jwtClaims = JwtClaims().apply {
+            issuer = testIssuer
+            subject = testSubject
+            audience = testAudience
+            expirationTime = testExp
+            issuedAt = testIssueAt
+            setClaim(ClaimName.AT_HASH, testAtHash)
+        }
+
+        assertThat(jwtClaims.toIdTokenClaims()).isEqualTo(idTokenClaims)
+    }
+}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* tests for constants
* cover the null check branch in `fetchTokenByAuthorizationCode` and `fetchTokenByRefreshToken`
* `JwtClaims` extension
### Notes
We can't not mock inline functions in mockk, so the functions under the `http` package can not be tested directly. we test these functions by setting up a mock server and testing the fetch function in `CoreFetchTest`.
Reference: [Cannot objectMockk inline function](https://github.com/mockk/mockk/issues/55)
<img width="931" alt="image" src="https://user-images.githubusercontent.com/10806653/163971288-ab572e5f-5fb1-413c-a2ab-3d550db308a5.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2225

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT
