### PR TITLE
test(android-sdk): add test for logto utils

### DIFF
--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/util/LogtoUtils.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/util/LogtoUtils.kt
@@ -1,11 +1,12 @@
 package io.logto.sdk.android.util
 
+import java.util.Calendar
 import kotlin.math.floor
 
 object LogtoUtils {
     private const val MILLIS_PER_SECOND = 1000L
 
-    fun nowRoundToSec() = floor((System.currentTimeMillis() / MILLIS_PER_SECOND).toDouble()).toLong()
+    fun nowRoundToSec() = floor((Calendar.getInstance().timeInMillis / MILLIS_PER_SECOND).toDouble()).toLong()
 
     fun expiresAtFrom(startTime: Long, lifetime: Long): Long {
         return startTime + lifetime

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/util/LogtoUtilsTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/util/LogtoUtilsTest.kt
@@ -1,0 +1,39 @@
+package io.logto.sdk.android.util
+
+import com.google.common.truth.Truth.assertThat
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.Test
+import java.util.*
+
+class LogtoUtilsTest {
+
+    @Test
+    fun nowRoundToSec() {
+        val testMillis = 10000L
+        val calendarMock: Calendar = mockk()
+        mockkStatic(Calendar::class)
+        every { Calendar.getInstance() } returns calendarMock
+        every { calendarMock.timeInMillis } returns testMillis
+        assertThat(LogtoUtils.nowRoundToSec()).isEqualTo(10L)
+    }
+
+    @Test
+    fun expiresAtFrom() {
+        val startTime = 1234L
+        val lifeTime = 5678L
+        val expiresAt = LogtoUtils.expiresAtFrom(startTime, lifeTime)
+        assertThat(expiresAt).isEqualTo(startTime + lifeTime)
+    }
+
+    @Test
+    fun isDependencyInstalled() {
+        val installedDependency = "org.junit.Test"
+        assertThat(LogtoUtils.isDependencyInstalled(installedDependency)).isTrue()
+
+        val notInstalledDependencyIdentify = "notInstalled"
+        assertThat(LogtoUtils.isDependencyInstalled(notInstalledDependencyIdentify)).isFalse()
+    }
+}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* test(android-sdk): add test for logto utils

Since we can not mock `System.currentTimeMillis`, so use `Calendar` instead.
https://github.com/mockk/mockk/issues/98

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2226

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT