### PR TITLE
feat(android-sdk): use uri constructor to construct oidc config endpoint

### DIFF
--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/extension/LogtoConfigExt.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/extension/LogtoConfigExt.kt
@@ -1,6 +1,10 @@
 package io.logto.sdk.android.extension
 
+import android.net.Uri
 import io.logto.sdk.android.type.LogtoConfig
 
 val LogtoConfig.oidcConfigEndpoint: String
-    get() = "$endpoint/oidc/.well-known/openid-configuration"
+    get() = Uri.parse(endpoint)
+        .buildUpon()
+        .appendEncodedPath("oidc/.well-known/openid-configuration")
+        .toString()

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
@@ -23,7 +23,10 @@ import org.jose4j.jwk.JsonWebKeySet
 import org.jose4j.jwt.consumer.InvalidJwtException
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class LogtoClientTest {
     private val oidcConfigResponseMock: OidcConfigResponse = mockk()
     private val jwksMock: JsonWebKeySet = mockk()

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/extension/LogtoConfigExtKtTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/extension/LogtoConfigExtKtTest.kt
@@ -4,12 +4,25 @@ import com.google.common.truth.Truth.assertThat
 import io.logto.sdk.android.type.LogtoConfig
 
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class LogtoConfigExtKtTest {
     @Test
-    fun getOidcConfigEndpoint() {
+    fun `should get correct oidc config endpoint by endpoint without slash`() {
         val testLogtoConfig = LogtoConfig(
             endpoint = "https://logto.dev",
+            clientId = "client",
+        )
+        assertThat(testLogtoConfig.oidcConfigEndpoint)
+            .isEqualTo("https://logto.dev/oidc/.well-known/openid-configuration")
+    }
+
+    @Test
+    fun `should get correct oidc config endpoint by endpoint with slash`() {
+        val testLogtoConfig = LogtoConfig(
+            endpoint = "https://logto.dev/",
             clientId = "client",
         )
         assertThat(testLogtoConfig.oidcConfigEndpoint)


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* feat(android-sdk): use uri uonstructor to construct oidc config endpoint
* make all related tests run with `RobolectricTestRunner` for we need to support the `android.net.Uri` to be run in JVM when running UTs.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2241

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT