### PR TITLE
test(android-sdk): web social session

### DIFF
--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSession.kt
@@ -20,7 +20,7 @@ class WebSocialSession(
 
     fun handleResult(data: Uri) {
         val continueSignInUri = try {
-            Uri.parse(callbackUri).buildUpon().encodedQuery(data.encodedQuery).build()
+            Uri.parse(callbackUri).buildUpon().encodedQuery(data.query).build()
         } catch (_: UnsupportedOperationException) {
             completion.onComplete(
                 SocialException(SocialException.Type.UNABLE_TO_CONSTRUCT_CALLBACK_URI),

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSession.kt
@@ -20,7 +20,7 @@ class WebSocialSession(
 
     fun handleResult(data: Uri) {
         val continueSignInUri = try {
-            Uri.parse(callbackUri).buildUpon().query(data.query).build()
+            Uri.parse(callbackUri).buildUpon().encodedQuery(data.encodedQuery).build()
         } catch (_: UnsupportedOperationException) {
             completion.onComplete(
                 SocialException(SocialException.Type.UNABLE_TO_CONSTRUCT_CALLBACK_URI),

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSessionTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSessionTest.kt
@@ -1,0 +1,125 @@
+package io.logto.sdk.android.auth.social.web
+
+import android.app.Activity
+import android.net.Uri
+import com.google.common.truth.Truth.assertThat
+import io.logto.sdk.android.auth.social.SocialException
+import io.logto.sdk.android.completion.Completion
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WebSocialSessionTest {
+
+    private val mockActivity: Activity = mockk()
+    private val mockCompletion: Completion<SocialException, String> = mockk()
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun start() {
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val dummyRedirectTo = "dummyRedirectTo"
+        val dummyCallbackUri = "dummyCallbackUri"
+
+        val webSocialSession = WebSocialSession(
+            mockActivity,
+            dummyRedirectTo,
+            dummyCallbackUri,
+            mockCompletion
+        )
+
+        mockkObject(WebSocialResultActivity.Companion)
+
+        every { WebSocialResultActivity.Companion.registerSession(any()) } just Runs
+
+        webSocialSession.start()
+
+        verify {
+            WebSocialResultActivity.Companion.registerSession(webSocialSession)
+            mockActivity.startActivity(any())
+        }
+    }
+
+    @Test
+    fun handleResult() {
+        every { mockCompletion.onComplete(any(), any()) } just Runs
+
+        val dummyRedirectTo = "dummyRedirectTo"
+        val validCallbackUri = "https://logto.dev/sign-in/github"
+
+
+        val webSocialSession = WebSocialSession(
+            mockActivity,
+            dummyRedirectTo,
+            validCallbackUri,
+            mockCompletion
+        )
+
+        val resultUri = Uri.parse("logto-callback://io.logto.test/web?code=testCode")
+
+        webSocialSession.handleResult(resultUri)
+
+        val expectedContinueSigUri = Uri.parse(validCallbackUri).buildUpon().encodedQuery(resultUri.query).build()
+
+        assertThat(expectedContinueSigUri.toString())
+            .isEqualTo("https://logto.dev/sign-in/github?code=testCode")
+
+        verify {
+            mockCompletion.onComplete(null, expectedContinueSigUri.toString())
+        }
+    }
+
+    @Test
+    fun `should complete with exception if can not construct the continue sign in uri`() {
+        val socialExceptionCapture = mutableListOf<SocialException?>()
+        val continueSignInUriCapture = mutableListOf<String?>()
+
+        every { mockCompletion.onComplete(any(), any()) } just Runs
+
+        val dummyRedirectTo = "dummyRedirectTo"
+        val validCallbackUri = "https://logto.dev/sign-in/github"
+
+        val webSocialSession = WebSocialSession(
+            mockActivity,
+            dummyRedirectTo,
+            validCallbackUri,
+            mockCompletion
+        )
+
+        val resultUri = Uri.parse("logto-callback://io.logto.test/web?code=testCode")
+
+        mockkStatic(Uri::class)
+        every { Uri.parse(any()) } throws UnsupportedOperationException()
+
+        webSocialSession.handleResult(resultUri)
+
+        verify {
+            mockCompletion.onComplete(
+                captureNullable(socialExceptionCapture),
+                captureNullable(continueSignInUriCapture)
+            )
+        }
+
+        assertThat(socialExceptionCapture.last())
+            .hasMessageThat()
+            .isEqualTo(SocialException.Type.UNABLE_TO_CONSTRUCT_CALLBACK_URI.code)
+
+        assertThat(continueSignInUriCapture.last()).isNull()
+    }
+}

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSessionTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/social/web/WebSocialSessionTest.kt
@@ -86,7 +86,7 @@ class WebSocialSessionTest {
     }
 
     @Test
-    fun `should complete with exception if can not construct the continue sign in uri`() {
+    fun `should complete with exception if cannot construct the continue sign in uri`() {
         val socialExceptionCapture = mutableListOf<SocialException?>()
         val continueSignInUriCapture = mutableListOf<String?>()
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* test(android-sdk): add ut for logto web social session
### Note
use `encodedQuery` in `Uri` construction for we will get an encoded string in the final URI string.

expected -> `'code=testCode'`
query -> `'code%3DtestCode'`
encodedQuery -> `'code=testCode'`

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2226

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT