### PR TITLE
refactor(android-sdk): `signInWithBrowser` -> `signIn`

### DIFF
--- a/android-sample-java/app/src/main/java/io/logto/demo4j/fragment/LoginFragment.java
+++ b/android-sample-java/app/src/main/java/io/logto/demo4j/fragment/LoginFragment.java
@@ -25,7 +25,7 @@ public class LoginFragment extends Fragment {
 
     private void initView(View view) {
         view.findViewById(R.id.sign_in_button).setOnClickListener( v -> {
-            logtoViewModel.signInWithBrowser(requireActivity());
+            logtoViewModel.signIn(requireActivity());
         });
     }
 

--- a/android-sample-java/app/src/main/java/io/logto/demo4j/viewmodel/LogtoViewModel.java
+++ b/android-sample-java/app/src/main/java/io/logto/demo4j/viewmodel/LogtoViewModel.java
@@ -49,8 +49,8 @@ public class LogtoViewModel extends AndroidViewModel {
     }
 
 
-    public void signInWithBrowser(Activity context) {
-        logtoClient.signInWithBrowser(
+    public void signIn(Activity context) {
+        logtoClient.signIn(
                 context,
                 "io.logto.android://io.logto.sample/callback",
                 logtoException -> {

--- a/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/fragment/LoginFragment.kt
+++ b/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/fragment/LoginFragment.kt
@@ -31,7 +31,7 @@ class LoginFragment : Fragment() {
 
     private fun initView(view: View) {
         view.findViewById<Button>(R.id.sign_in_button).setOnClickListener {
-            logtoViewModel.signInWithBrowser(requireActivity())
+            logtoViewModel.signIn(requireActivity())
         }
     }
 

--- a/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/viewmodel/LogtoViewModel.kt
+++ b/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/viewmodel/LogtoViewModel.kt
@@ -39,8 +39,8 @@ class LogtoViewModel(application: Application) : AndroidViewModel(application) {
     val logtoException: LiveData<LogtoException>
         get() = _logtoException
 
-    fun signInWithBrowser(context: Activity) {
-        logtoClient.signInWithBrowser(context, "io.logto.android://io.logto.sample/callback",) {
+    fun signIn(context: Activity) {
+        logtoClient.signIn(context, "io.logto.android://io.logto.sample/callback",) {
             it?.let { _logtoException.postValue(it) } ?: _authenticated.postValue(logtoClient.isAuthenticated)
         }
     }

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -62,7 +62,7 @@ open class LogtoClient(
         loadFromStorage()
     }
 
-    fun signInWithBrowser(
+    fun signIn(
         context: Activity,
         redirectUri: String,
         completion: EmptyCompletion<LogtoException>,

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
@@ -83,7 +83,7 @@ class LogtoClientTest {
     }
 
     @Test
-    fun `signInWithBrowser should complete with exception if get oidc config failed`() {
+    fun `signIn should complete with exception if get oidc config failed`() {
         logtoClient = LogtoClient(logtoConfigMock, mockk())
         mockkObject(logtoClient)
         every { logtoClient.getOidcConfig(any()) } answers {
@@ -93,7 +93,7 @@ class LogtoClientTest {
             )
         }
 
-        logtoClient.signInWithBrowser(mockk(), "dummyRedirectUri") { logtoException ->
+        logtoClient.signIn(mockk(), "dummyRedirectUri") { logtoException ->
             assertThat(logtoException)
                 .hasMessageThat()
                 .isEqualTo(LogtoException.Message.UNABLE_TO_FETCH_OIDC_CONFIG.name)
@@ -101,7 +101,7 @@ class LogtoClientTest {
     }
 
     @Test
-    fun `signInWithBrowser should start a logto auth session`() {
+    fun `signIn should start a logto auth session`() {
         logtoClient = LogtoClient(logtoConfigMock, mockk())
         mockkObject(logtoClient)
         every { logtoClient.getOidcConfig(any()) } answers {
@@ -116,7 +116,7 @@ class LogtoClientTest {
             anyConstructed<LogtoAuthSession>().start()
         } just Runs
 
-        logtoClient.signInWithBrowser(mockk(), "dummyRedirectUri", mockk())
+        logtoClient.signIn(mockk(), "dummyRedirectUri", mockk())
 
         verify {
             anyConstructed<LogtoAuthSession>().start()


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Our sign-in method will invoke the sign-in process by the webView, browser, or native, so rename `signInWithBrowser` to `signIn`.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
N/A

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT