### PR TITLE
fix(android-sdk): disable web view activity configuration change

### DIFF
--- a/android-sdk/android/src/main/AndroidManifest.xml
+++ b/android-sdk/android/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <application>
         <activity android:name=".auth.logto.LogtoWebViewAuthActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
             android:launchMode="singleTop" />
 
         <activity android:name=".auth.social.web.WebSocialResultActivity"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Since the webView activity will reload the page when configuration changes, so disable the configuration change process logic to keep our login page state.

Refer to: https://developer.android.com/guide/topics/resources/runtime-changes

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
N/A

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test in the sample app.