### PR TITLE
feat: support prompt setup in kotlin sdk

### DIFF
--- a/android-sample-java/app/src/main/java/io/logto/demo4j/viewmodel/LogtoViewModel.java
+++ b/android-sample-java/app/src/main/java/io/logto/demo4j/viewmodel/LogtoViewModel.java
@@ -10,6 +10,7 @@ import io.logto.sdk.android.LogtoClient;
 import io.logto.sdk.android.exception.LogtoException;
 import io.logto.sdk.android.type.AccessToken;
 import io.logto.sdk.android.type.LogtoConfig;
+import io.logto.sdk.core.constant.PromptValue;
 import io.logto.sdk.core.type.IdTokenClaims;
 
 public class LogtoViewModel extends AndroidViewModel {
@@ -23,7 +24,8 @@ public class LogtoViewModel extends AndroidViewModel {
             "94fKrpteyMI6BAy9K3pdX",
             null,
             null,
-            true
+            true,
+            PromptValue.CONSENT
     );
 
     private final LogtoClient logtoClient = new LogtoClient(logtoConfig, getApplication());

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSession.kt
@@ -38,6 +38,7 @@ class LogtoAuthSession(
             state = state,
             scopes = logtoConfig.scopes,
             resources = logtoConfig.resources,
+            prompt = logtoConfig.prompt,
         )
 
         LogtoWebViewAuthActivity.launch(context, signInUri)

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/exception/LogtoException.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/exception/LogtoException.kt
@@ -7,7 +7,6 @@ class LogtoException(
     var detail: String? = null
     enum class Type {
         NOT_AUTHENTICATED,
-        NO_REFRESH_TOKEN_FOUND,
         UNGRANTED_RESOURCE_FOUND,
         USER_CANCELED,
         INVALID_REDIRECT_URI,

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/type/LogtoConfig.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/type/LogtoConfig.kt
@@ -1,5 +1,6 @@
 package io.logto.sdk.android.type
 
+import io.logto.sdk.core.constant.PromptValue
 import io.logto.sdk.core.util.ScopeUtils
 
 class LogtoConfig(
@@ -8,6 +9,7 @@ class LogtoConfig(
     scopes: List<String>? = null,
     val resources: List<String>? = null,
     val usingPersistStorage: Boolean = false,
+    val prompt: String = PromptValue.CONSENT,
 ) {
     val scopes = ScopeUtils.withReservedScopes(scopes)
 }

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
@@ -252,7 +252,7 @@ class LogtoClientTest {
         every { logtoClient.isAuthenticated } returns true
 
         logtoClient.getAccessToken { logtoException, result ->
-            assertThat(logtoException).hasMessageThat().contains(LogtoException.Type.NO_REFRESH_TOKEN_FOUND.name)
+            assertThat(logtoException).hasMessageThat().contains(LogtoException.Type.NOT_AUTHENTICATED.name)
             assertThat(result).isNull()
         }
     }

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSessionTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSessionTest.kt
@@ -59,7 +59,7 @@ class LogtoAuthSessionTest {
         val mockCompletion: Completion<LogtoException, CodeTokenResponse> = mockk()
 
         every {
-            Core.generateSignInUri(any(), any(), any(), any(), any(), any(), any())
+            Core.generateSignInUri(any(), any(), any(), any(), any(), any(), any(), any())
         } returns "testSignInUri"
 
         val logtoAuthSession = LogtoAuthSession(
@@ -116,7 +116,7 @@ class LogtoAuthSessionTest {
 
         verify(exactly = 0){
             LogtoAuthManager.handleAuthStart(logtoAuthSession)
-            Core.generateSignInUri(any(), any(), any(), any(), any(), any(), any())
+            Core.generateSignInUri(any(), any(), any(), any(), any(), any(), any(), any())
             mockActivity.startActivity(any())
         }
     }

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/Core.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/Core.kt
@@ -27,6 +27,7 @@ object Core {
         state: String,
         scopes: List<String>?,
         resources: List<String>?,
+        prompt: String?,
     ): String {
         val constructedUri = authorizationEndpoint.toHttpUrlOrNull() ?: throw UriConstructionException(
             UriConstructionException.Type.INVALID_ENDPOINT,
@@ -37,10 +38,10 @@ object Core {
             addQueryParameter(QueryKey.CODE_CHALLENGE_METHOD, CodeChallengeMethod.S256)
             addQueryParameter(QueryKey.STATE, state)
             addQueryParameter(QueryKey.REDIRECT_URI, redirectUri)
-            addQueryParameter(QueryKey.PROMPT, PromptValue.CONSENT)
             addQueryParameter(QueryKey.RESPONSE_TYPE, ResponseType.CODE)
             addQueryParameter(QueryKey.SCOPE, ScopeUtils.withReservedScopes(scopes).joinToString(" "))
             resources?.let { for (value in it) { addQueryParameter(QueryKey.RESOURCE, value) } }
+            addQueryParameter(QueryKey.PROMPT, prompt ?: PromptValue.CONSENT)
         }.build().toString()
     }
 

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/PromptValue.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/PromptValue.kt
@@ -2,4 +2,5 @@ package io.logto.sdk.core.constant
 
 object PromptValue {
     const val CONSENT = "consent"
+    const val LOGIN = "login"
 }

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/CodeTokenResponse.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/CodeTokenResponse.kt
@@ -2,7 +2,7 @@ package io.logto.sdk.core.type
 
 data class CodeTokenResponse(
     val accessToken: String,
-    val refreshToken: String,
+    val refreshToken: String?,
     val idToken: String,
     val scope: String,
     val expiresIn: Long,

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreTest.kt
@@ -21,6 +21,7 @@ class CoreTest {
     private val testResourceVal1 = "api1.logto.dev"
     private val testResourceVal2 = "api2.logto.dev"
     private val testResources = listOf(testResourceVal1, testResourceVal2)
+    private val testPromptValue = PromptValue.CONSENT
 
     @Test
     fun `generateSignInUri should contain expected queries in result`() {
@@ -31,7 +32,8 @@ class CoreTest {
             codeChallenge = testCodeChallenge,
             state = testState,
             scopes = testScopes,
-            resources = testResources
+            resources = testResources,
+            prompt = testPromptValue,
         )
 
         signInUri.toHttpUrl().apply {
@@ -69,7 +71,8 @@ class CoreTest {
             codeChallenge = testCodeChallenge,
             state = testState,
             scopes = scopes,
-            resources = testResources
+            resources = testResources,
+            prompt = testPromptValue,
         )
 
         signInUri.toHttpUrl().apply {
@@ -91,7 +94,8 @@ class CoreTest {
             codeChallenge = testCodeChallenge,
             state = testState,
             scopes = testScopes,
-            resources = null
+            resources = null,
+            prompt = testPromptValue,
         )
 
         signInUri.toHttpUrl().apply {
@@ -112,7 +116,8 @@ class CoreTest {
                 codeChallenge = testCodeChallenge,
                 state = testState,
                 scopes = testScopes,
-                resources = testResources
+                resources = testResources,
+                prompt = testPromptValue,
             )
         }
 
@@ -128,7 +133,8 @@ class CoreTest {
             codeChallenge = testCodeChallenge,
             state = testState,
             scopes = null,
-            resources = testResources
+            resources = testResources,
+            prompt = testPromptValue,
         )
 
         signInUri.toHttpUrl().apply {
@@ -149,7 +155,8 @@ class CoreTest {
             codeChallenge = testCodeChallenge,
             state = testState,
             scopes = listOf(ReservedScope.OFFLINE_ACCESS),
-            resources = testResources
+            resources = testResources,
+            prompt = testPromptValue,
         )
 
         signInUri.toHttpUrl().apply {
@@ -171,7 +178,8 @@ class CoreTest {
             codeChallenge = testCodeChallenge,
             state = testState,
             scopes = listOf(ReservedScope.OPENID),
-            resources = testResources
+            resources = testResources,
+            prompt = testPromptValue,
         )
 
         signInUri.toHttpUrl().apply {
@@ -193,7 +201,8 @@ class CoreTest {
             codeChallenge = testCodeChallenge,
             state = testState,
             scopes = listOf(ReservedScope.PROFILE),
-            resources = testResources
+            resources = testResources,
+            prompt = testPromptValue,
         )
 
         signInUri.toHttpUrl().apply {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`prompt` value setup is now supported by our SDK.
* Change the refresh token in the `CodeTokenResponse` to be optional for we won't get a refresh token from it if the prompt value is `login`.(Refer to: https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1649906832335309)
* Change the error returned from `NO_REFRESH_TOKEN_FOUND` to `NOT_AUTHENTICATED` in the `getAccessToken` method when this method cannot retrieve a valid access token and try to refresh for a new one, but no refresh token is valid. (Refer to: https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1655869439813809)
* Fix Bug: `signOut` method in the `LogtoClient` should complete the process when no refresh token is provided.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test in the Android app.