### PR TITLE
fix(kotlin): getAccessTokenByRefreshToken should not return idToken

### DIFF
--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -246,8 +246,8 @@ open class LogtoClient(
                 tokenEndpoint = requireNotNull(oidcConfig).tokenEndpoint,
                 clientId = logtoConfig.appId,
                 refreshToken = byRefreshToken,
-                resource = resource,
-                scopes = null,
+                resource = resource,å
+                scopes = listOf("offline_access"), // Force remove openid scope from the refresh token response
             ) { fetchRefreshedTokenException, fetchedTokenResponse ->
                 fetchRefreshedTokenException?.let {
                     pendingRefreshTokenCompletion.remove(byRefreshToken)?.map { pendingCompletion ->

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -246,8 +246,9 @@ open class LogtoClient(
                 tokenEndpoint = requireNotNull(oidcConfig).tokenEndpoint,
                 clientId = logtoConfig.appId,
                 refreshToken = byRefreshToken,
-                resource = resource,å
-                scopes = listOf("offline_access"), // Force remove openid scope from the refresh token response
+                resource = resource,
+                // Force remove openid scope from the refresh token response
+                scopes = listOf("offline_access"),
             ) { fetchRefreshedTokenException, fetchedTokenResponse ->
                 fetchRefreshedTokenException?.let {
                     pendingRefreshTokenCompletion.remove(byRefreshToken)?.map { pendingCompletion ->


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
getAccessTokenByRefreshToken should not return idToken. Per our offline discussion always pass-in `offline-access` as scopes param.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT passed
@xiaoyijun  cc: @logto-io/eng 