### PR TITLE
fix(android-sdk): role names should only contain not-null string value

### DIFF
--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/IdTokenClaims.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/IdTokenClaims.kt
@@ -12,5 +12,5 @@ data class IdTokenClaims(
     val name: String?,
     val username: String?,
     val avatar: String?,
-    val roleNames: List<String?>?,
+    val roleNames: List<String>?,
 )


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(android-sdk): role names should only contain not-null string value

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT Passed.