### PR TITLE
fix(android-sdk): should not export `LogtoWebViewAuthActivity`

### DIFF
--- a/android-sdk/android/src/main/AndroidManifest.xml
+++ b/android-sdk/android/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
 
     <application>
         <activity android:name=".auth.logto.LogtoWebViewAuthActivity"
-            android:exported="true"
+            android:exported="false"
             android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
             android:launchMode="singleTop" />
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(android-sdk): should not export `LogtoWebViewAuthActivity`

The webview activity sets “android:exported=true” enabling other applications to access the webview and exposing the cookies set and the authentication to be accessed by other apps outside the native application context, so set the `android:exported` to `false` to prevent this risk.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the Android sample app.
