### PR TITLE
fix(android-sdk): skip logto core type obfuscation

### DIFF
--- a/android-sdk/android/build.gradle.kts
+++ b/android-sdk/android/build.gradle.kts
@@ -22,6 +22,8 @@ android {
     defaultConfig {
         minSdk = 24
         targetSdk = 30
+
+        consumerProguardFile("./proguard-rules.pro")
     }
 
     sourceSets {

--- a/android-sdk/android/proguard-rules.pro
+++ b/android-sdk/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class io.logto.sdk.core.type.** { *; }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
When a project uses the Logto Android SDK and builds with proguard, the data types in the `io.logto.sdk.core.type` package will be obfuscated, and this causes a bug when Gson deserializes the data type.

<img width="840" alt="image" src="https://user-images.githubusercontent.com/10806653/205854044-f4b06aca-0deb-42f3-b915-8c7df3809262.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
