### PR TITLE
fix(core): Fix `ResponseException::responseContent` population

### DIFF
--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/http/HttpRequest.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/http/HttpRequest.kt
@@ -37,7 +37,7 @@ fun makeRequest(
                 completion.onComplete(
                     ResponseException(ResponseException.Type.REQUEST_FAILED).apply {
                         responseMessage = response.message
-                        responseContent = response.body?.toString()
+                        responseContent = response.body?.string()
                     },
                     null,
                 )
@@ -71,7 +71,7 @@ fun makeRequest(
             } ?: completion.onComplete(
                 ResponseException(ResponseException.Type.REQUEST_FAILED).apply {
                     responseMessage = response.message
-                    responseContent = response.body?.toString()
+                    responseContent = response.body?.string()
                 },
             )
         }


### PR DESCRIPTION
`response.body?.toString()` is returning the `response.body?` instance memory address Example:
```hava
okhttp3.internal.http.RealResponseBody@7cb56da5
```

`response.body?.string()` must be used instead. See https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/string/

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->
