### PR TITLE
refactor(core): make `refreshToken` in `RefreshTokenTokenResponse` optional

### DIFF
--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/RefreshTokenTokenResponse.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/RefreshTokenTokenResponse.kt
@@ -2,7 +2,7 @@ package io.logto.sdk.core.type
 
 data class RefreshTokenTokenResponse(
     val accessToken: String,
-    val refreshToken: String,
+    val refreshToken: String?,
     val idToken: String?,
     val scope: String,
     val expiresIn: Long,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

According to [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-6), the server MAY issue a refresh token when refreshing a token, not always.

Note: Since in the previous implementation, the `refreshToken` is used in an optional way, so we can change the type directly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
