### PR TITLE
fix(core): add roles and organization-related data for `userInfoResponse`

### DIFF
--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/UserInfoResponse.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/UserInfoResponse.kt
@@ -24,6 +24,15 @@ data class UserInfoResponse(
     // Scope `identities`
     val identities: JsonObject?,
 
+    // Scope `roles`
+    val roles: List<String>?,
+
+    // Scope `urn:logto:scope:organizations`
+    val organizations: List<String>?,
+
+    // Scope `urn:logto:scope:organization_roles`
+    val organizationRoles: List<String>?,
+
     // Scope `urn:logto:scope:organizations`
     val organizationData: List<Organization>?,
 )

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/type/UserInfoResponseTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/type/UserInfoResponseTest.kt
@@ -15,6 +15,9 @@ class UserInfoResponseTest {
     private val phoneNumberVerified = true
     private val customData = JsonObject()
     private val identities = JsonObject()
+    private val roles = listOf("role1", "role2")
+    private val organizations = listOf("org_id")
+    private val organizationRoles = listOf("viewer", "editor")
     private val organizationData = listOf(
         Organization("org_id", "org_name", "org_desc"),
     )
@@ -30,6 +33,9 @@ class UserInfoResponseTest {
         phoneNumberVerified = phoneNumberVerified,
         customData = customData,
         identities = identities,
+        roles = roles,
+        organizations = organizations,
+        organizationRoles = organizationRoles,
         organizationData = organizationData,
     )
 
@@ -45,6 +51,9 @@ class UserInfoResponseTest {
         assertThat(userInfoResponse.phoneNumberVerified).isEqualTo(phoneNumberVerified)
         assertThat(userInfoResponse.customData).isEqualTo(customData)
         assertThat(userInfoResponse.identities).isEqualTo(identities)
+        assertThat(userInfoResponse.roles).isEqualTo(roles)
+        assertThat(userInfoResponse.organizations).isEqualTo(organizations)
+        assertThat(userInfoResponse.organizationRoles).isEqualTo(organizationRoles)
         assertThat(userInfoResponse.organizationData).isEqualTo(organizationData)
     }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add missing `roles`, `organizations` and `organization roles` fields for user info response data.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally & UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
