### PR TITLE
feat(core): add more options for sign-in uri generation

### DIFF
--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/Core.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/Core.kt
@@ -35,8 +35,15 @@ object Core {
             addQueryParameter(QueryKey.REDIRECT_URI, options.redirectUri)
             addQueryParameter(QueryKey.RESPONSE_TYPE, ResponseType.CODE)
 
-            val usedScopes = ScopeUtils.withDefaultScopes(options.scopes)
-            addQueryParameter(QueryKey.SCOPE, usedScopes.joinToString(" "))
+            val usedScopes = if (options.includeReservedScopes == true) {
+                ScopeUtils.withDefaultScopes(options.scopes)
+            } else {
+                options.scopes.orEmpty()
+            }
+
+            if (usedScopes.isNotEmpty()) {
+                addQueryParameter(QueryKey.SCOPE, usedScopes.joinToString(" "))
+            }
 
             val usedResources = options.resources.orEmpty()
             for (value in usedResources) { addQueryParameter(QueryKey.RESOURCE, value) }
@@ -48,6 +55,22 @@ object Core {
             }
 
             addQueryParameter(QueryKey.PROMPT, options.prompt ?: PromptValue.CONSENT)
+
+            options.loginHint?.let {
+                addQueryParameter(QueryKey.LOGIN_HINT, it)
+            }
+
+            options.firstScreen?.let {
+                addQueryParameter(QueryKey.FIRST_SCREEN, it)
+            }
+
+            options.identifiers?.let {
+                addQueryParameter(QueryKey.IDENTIFIER, it.joinToString(" "))
+            }
+
+            options.extraParams?.forEach { (key, value) ->
+                addQueryParameter(key, value)
+            }
         }.build().toString()
     }
 

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/FirstScreen.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/FirstScreen.kt
@@ -1,0 +1,10 @@
+package io.logto.sdk.core.constant
+
+object FirstScreen {
+    const val SIGN_IN = "sign_in"
+    const val REGISTER = "register"
+    const val RESET_PASSWORD = "reset_password"
+    const val IDENTIFIER_SIGN_IN = "identifier:sign_in"
+    const val IDENTIFIER_REGISTER = "identifier:register"
+    const val SINGLE_SIGN_ON = "single_sign_on"
+}

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/Identifier.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/Identifier.kt
@@ -1,0 +1,7 @@
+package io.logto.sdk.core.constant
+
+object Identifier {
+    const val USERNAME = "username"
+    const val EMAIL = "email"
+    const val PHONE = "phone"
+}

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/QueryKey.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/constant/QueryKey.kt
@@ -19,4 +19,8 @@ object QueryKey {
     const val STATE = "state"
     const val TOKEN = "token"
     const val ORGANIZATION_ID = "organization_id"
+    const val LOGIN_HINT = "login_hint"
+    const val FIRST_SCREEN = "first_screen"
+    const val IDENTIFIER = "identifier"
+    const val DIRECT_SIGN_IN = "direct_sign_in"
 }

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/GenerateSignInUriOptions.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/type/GenerateSignInUriOptions.kt
@@ -9,4 +9,9 @@ class GenerateSignInUriOptions(
     val scopes: List<String>? = null,
     val resources: List<String>? = null,
     val prompt: String? = null,
+    val loginHint: String? = null,
+    val firstScreen: String? = null,
+    val identifiers: List<String>? = null,
+    val extraParams: Map<String, String>? = null,
+    val includeReservedScopes: Boolean? = true,
 )


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add more options for sign-in uri generation in core sdk to align with other SDKs.

These options are used to generate query params in sign-in uri:
- `loginHint`: `login_hint`
- `firstScreen`: `first_screen`
- `identifier`: `identifier`

The `extraParams` option is used to generate extra params in the sing-in uri.

The `includeReservedScopes` option is used to control if the reserved scopes (`openid`, `offline_access` and `profile`) is present in the sign-in uri.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT and test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
