### PR TITLE
chore: upgrade SDK dependencies to address Dependabot alerts

### DIFF
--- a/android-sample-java/app/src/main/java/io/logto/demo4j/viewmodel/LogtoViewModel.java
+++ b/android-sample-java/app/src/main/java/io/logto/demo4j/viewmodel/LogtoViewModel.java
@@ -25,7 +25,8 @@ public class LogtoViewModel extends AndroidViewModel {
             null,
             null,
             true,
-            PromptValue.CONSENT
+            PromptValue.CONSENT,
+            true
     );
 
     private final LogtoClient logtoClient = new LogtoClient(logtoConfig, getApplication());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,14 +8,13 @@ androidx-legacy = "1.0.0"
 androidx-navigation = "2.3.5"
 androidx-test-ext-junit = "1.1.3"
 detekt = "1.20.0-RC2"
-gson = "2.8.9"
-jose4j = "0.7.9"
+gson = "2.10.1"
+jose4j = "0.9.6"
 kotlin = "1.5.32"
 kover = "0.5.0"
-logbackClassic = "1.2.10"
 material = "1.4.0"
 mockk = "1.12.2"
-okhttp = "4.9.3"
+okhttp = "4.11.0"
 robolectric = "4.6"
 truth = "1.1.3"
 wechatSdkAndroid = "6.8.0"
@@ -38,7 +37,6 @@ detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plu
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref = "jose4j" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-logbackClassic = { module = "ch.qos.logback:logback-classic", version.ref = "logbackClassic" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }

--- a/kotlin-sdk/kotlin/build.gradle.kts
+++ b/kotlin-sdk/kotlin/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
 
     implementation(libs.okhttp)
     implementation(libs.gson)
-    implementation(libs.logbackClassic)
 
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.mockk)


### PR DESCRIPTION
## Summary

Bumps SDK dependencies that the Android consumer flagged via Dependabot, plus a small Java sample fix surfaced while validating the build.

**Dependency changes (`kotlin-sdk`)**

| Dependency | From | To | Note |
|---|---|---|---|
| `ch.qos.logback:logback-classic` | 1.2.10 | **removed** | Dead dependency — declared but never imported anywhere in the source. JVM-only library that should not have been on the Android consumer's runtime classpath in the first place. |
| `org.bitbucket.b_c:jose4j` | 0.7.9 | 0.9.6 | Latest stable. |
| `com.squareup.okhttp3:okhttp` | 4.9.3 | 4.11.0 | 4.12.0 is compiled with Kotlin 1.8 metadata which is incompatible with the project's Kotlin 1.5.32; 4.11.0 is the latest version that works. Going further requires bumping Kotlin (out of scope). |
| `com.google.code.gson:gson` | 2.8.9 | 2.10.1 | gson 2.11+ introduces a transitive dependency on `error_prone_annotations` (2.27+) whose newer class file format breaks AGP 7.1.2's D8 dexer (`build-android-sample-kotlin` fails). 2.10.1 is the last release without that transitive. |

**Java sample fix**

`LogtoConfig` was extended with a 7th parameter `includeReservedScopes` in #234. Kotlin callers are unaffected (default value), but the Java sample's positional constructor call broke. Pass `true` explicitly to match the Kotlin default.

## Testing

tested locally:
- `./gradlew :kotlin-sdk:kotlin:test` — all pass (jose4j-related token tests covered)
- `./gradlew :android-sdk:android:compileDebugKotlin :android-sdk:android:compileReleaseKotlin` — pass
- `./gradlew checkCodeStyle lintAndroid` — pass
- `./gradlew build-android-sample-kotlin` — pass
- `./gradlew build-android-sample-java` — pass (was failing on master due to the constructor mismatch)

> Note: `./gradlew :android-sdk:android:test` fails locally on JDK 17 due to a pre-existing Robolectric 4.6 + JDK 17 incompatibility (`sun.misc.Unsafe.defineAnonymousClass` removed). CI uses JDK 11 where it passes. This is unrelated to this PR — `master` reproduces the same failure.

## Checklist

- [x] unit tests