### PR TITLE
fix: replace HttpUrl for callback URI parsing

### DIFF
--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
@@ -26,7 +26,10 @@ internal object LogtoAuthManager {
     } ?: false
 
     private fun Uri.matchesRedirectUri(redirectUri: Uri): Boolean {
-        if (!isHierarchical || !redirectUri.isHierarchical || fragment != null || redirectUri.fragment != null) {
+        if (!isHierarchical || !redirectUri.isHierarchical) {
+            return false
+        }
+        if (fragment != null || redirectUri.fragment != null) {
             return false
         }
 

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
@@ -26,7 +26,7 @@ internal object LogtoAuthManager {
     } ?: false
 
     private fun Uri.matchesRedirectUri(redirectUri: Uri): Boolean {
-        if (!isHierarchical || !redirectUri.isHierarchical) {
+        if (!isHierarchical || !redirectUri.isHierarchical || fragment != null || redirectUri.fragment != null) {
             return false
         }
 

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
@@ -3,6 +3,9 @@ package io.logto.sdk.android.auth.logto
 import android.annotation.SuppressLint
 import android.net.Uri
 
+private const val PERCENT_ENCODED_CHARACTER_LENGTH = 3
+private const val HEX_RADIX = 16
+
 internal object LogtoAuthManager {
     @SuppressLint("StaticFieldLeak")
     internal var logtoAuthSession: LogtoAuthSession? = null
@@ -33,11 +36,60 @@ internal object LogtoAuthManager {
             return false
         }
 
-        return scheme == redirectUri.scheme &&
-            encodedAuthority == redirectUri.encodedAuthority &&
-            encodedPath == redirectUri.encodedPath &&
+        return scheme?.lowercase() == redirectUri.scheme?.lowercase() &&
+            normalizedAuthority() == redirectUri.normalizedAuthority() &&
+            encodedPath.orEmpty().normalizePath() == redirectUri.encodedPath.orEmpty().normalizePath() &&
             redirectUri.queryParameterNames.all { queryKey ->
                 getQueryParameters(queryKey) == redirectUri.getQueryParameters(queryKey)
             }
+    }
+
+    private fun Uri.normalizedAuthority(): String? = encodedAuthority?.lowercase()
+
+    private fun String.normalizePath(): String = normalizePercentEncodedUnreserved()
+
+    private fun String.normalizePercentEncodedUnreserved(): String {
+        val normalizedValue = StringBuilder()
+        var index = 0
+
+        while (index < length) {
+            val normalizedCharacter = normalizedPercentEncodedCharacterAt(index)
+            if (normalizedCharacter != null) {
+                normalizedValue.append(normalizedCharacter)
+                index += PERCENT_ENCODED_CHARACTER_LENGTH
+                continue
+            }
+
+            normalizedValue.append(this[index])
+            index += 1
+        }
+
+        return normalizedValue.toString()
+    }
+
+    private fun String.normalizedPercentEncodedCharacterAt(index: Int): String? {
+        if (this[index] != '%' || index + PERCENT_ENCODED_CHARACTER_LENGTH > length) {
+            return null
+        }
+
+        val hex = substring(index + 1, index + PERCENT_ENCODED_CHARACTER_LENGTH)
+        val char = hex.toIntOrNull(HEX_RADIX)?.toChar() ?: return null
+        return if (char.isUnreservedUriCharacter()) {
+            char.toString()
+        } else {
+            "%${hex.uppercase()}"
+        }
+    }
+
+    private fun Char.isUnreservedUriCharacter(): Boolean = when (this) {
+        in 'A'..'Z',
+        in 'a'..'z',
+        in '0'..'9',
+        '-',
+        '.',
+        '_',
+        '~',
+        -> true
+        else -> false
     }
 }

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
@@ -44,7 +44,19 @@ internal object LogtoAuthManager {
             }
     }
 
-    private fun Uri.normalizedAuthority(): String? = encodedAuthority?.lowercase()
+    private fun Uri.normalizedAuthority(): String? {
+        if (encodedAuthority == null) {
+            return null
+        }
+
+        host?.let { host ->
+            val userInfo = encodedUserInfo?.let { "$it@" }.orEmpty()
+            val port = if (port == -1) "" else ":$port"
+            return "$userInfo${host.lowercase()}$port"
+        }
+
+        return encodedAuthority
+    }
 
     private fun String.normalizePath(): String = normalizePercentEncodedUnreserved()
 

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
@@ -21,7 +21,20 @@ internal object LogtoAuthManager {
         logtoAuthSession = null
     }
 
-    fun isLogtoAuthResult(uri: Uri) = logtoAuthSession?.let {
-        uri.toString().startsWith(it.signInOptions.redirectUri)
+    fun isLogtoAuthResult(uri: Uri) = logtoAuthSession?.let { authSession ->
+        uri.matchesRedirectUri(Uri.parse(authSession.signInOptions.redirectUri))
     } ?: false
+
+    private fun Uri.matchesRedirectUri(redirectUri: Uri): Boolean {
+        if (!isHierarchical || !redirectUri.isHierarchical) {
+            return false
+        }
+
+        return scheme == redirectUri.scheme &&
+            encodedAuthority == redirectUri.encodedAuthority &&
+            encodedPath == redirectUri.encodedPath &&
+            redirectUri.queryParameterNames.all { queryKey ->
+                getQueryParameters(queryKey) == redirectUri.getQueryParameters(queryKey)
+            }
+    }
 }

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSession.kt
@@ -26,7 +26,7 @@ class LogtoAuthSession(
 
     fun start() {
         val redirectUri = Uri.parse(signInOptions.redirectUri)
-        if (redirectUri.scheme == null || !redirectUri.isHierarchical) {
+        if (redirectUri.scheme == null || !redirectUri.isHierarchical || redirectUri.fragment != null) {
             completion.onComplete(LogtoException(LogtoException.Type.INVALID_REDIRECT_URI), null)
             return
         }

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSession.kt
@@ -25,7 +25,8 @@ class LogtoAuthSession(
     private val state = GenerateUtils.generateState()
 
     fun start() {
-        if (Uri.parse(signInOptions.redirectUri) == Uri.EMPTY) {
+        val redirectUri = Uri.parse(signInOptions.redirectUri)
+        if (redirectUri.scheme == null || !redirectUri.isHierarchical) {
             completion.onComplete(LogtoException(LogtoException.Type.INVALID_REDIRECT_URI), null)
             return
         }

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
@@ -132,6 +132,23 @@ class LogtoAuthManagerTest {
     }
 
     @Test
+    fun `isLogtoAuthResult should keep user info case-sensitive when normalizing authority`() {
+        val redirectUri = "io.logto.android://User@IO.LOGTO.SAMPLE/callback"
+        val callbackUri = Uri.parse("io.logto.android://user@io.logto.sample/callback?state=state&code=code")
+
+        val logtoAuthSession = LogtoAuthSession(
+            mockk(),
+            mockk(),
+            mockk(),
+            SignInOptions(redirectUri = redirectUri),
+            mockk(),
+        )
+
+        LogtoAuthManager.handleAuthStart(logtoAuthSession)
+        assertThat(LogtoAuthManager.isLogtoAuthResult(callbackUri)).isFalse()
+    }
+
+    @Test
     fun `isLogtoAuthResult should return false if callback or redirect URI contains fragment`() {
         val redirectUri = "io.logto.android://io.logto.sample/callback"
         val callbackUriWithFragment = Uri.parse("$redirectUri?state=state&code=code#fragment")

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
@@ -115,6 +115,23 @@ class LogtoAuthManagerTest {
     }
 
     @Test
+    fun `isLogtoAuthResult should normalize URI scheme host and path`() {
+        val redirectUri = "io.logto.android://IO.LOGTO.SAMPLE/callback%7E"
+        val callbackUri = Uri.parse("IO.LOGTO.ANDROID://io.logto.sample/callback~?state=state&code=code")
+
+        val logtoAuthSession = LogtoAuthSession(
+            mockk(),
+            mockk(),
+            mockk(),
+            SignInOptions(redirectUri = redirectUri),
+            mockk(),
+        )
+
+        LogtoAuthManager.handleAuthStart(logtoAuthSession)
+        assertThat(LogtoAuthManager.isLogtoAuthResult(callbackUri)).isTrue()
+    }
+
+    @Test
     fun `isLogtoAuthResult should return false if callback or redirect URI contains fragment`() {
         val redirectUri = "io.logto.android://io.logto.sample/callback"
         val callbackUriWithFragment = Uri.parse("$redirectUri?state=state&code=code#fragment")

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
@@ -59,16 +59,54 @@ class LogtoAuthManagerTest {
 
     @Test
     fun `isLogtoAuthResult should return expected result with valid or invalid callback URI`() {
-        val redirectUri = "localhost:3001/callback"
-        val matchedCallbackUri = Uri.parse(redirectUri)
-        val mismatchedCallbackUri = Uri.parse("logto.dev/callback")
+        val redirectUri = "io.logto.android://io.logto.sample/callback"
+        val matchedCallbackUri = Uri.parse("$redirectUri?state=state&code=code")
+        val mismatchedCallbackUri = Uri.parse("io.logto.android://io.logto.sample/another-callback")
 
         val logtoAuthSession = LogtoAuthSession(
             mockk(),
             mockk(),
             mockk(),
             SignInOptions(redirectUri = redirectUri),
-            mockk()
+            mockk(),
+        )
+
+        LogtoAuthManager.handleAuthStart(logtoAuthSession)
+        assertThat(LogtoAuthManager.isLogtoAuthResult(matchedCallbackUri)).isTrue()
+        assertThat(LogtoAuthManager.isLogtoAuthResult(mismatchedCallbackUri)).isFalse()
+    }
+
+    @Test
+    fun `isLogtoAuthResult should return false when callback path is only a prefix match`() {
+        val redirectUri = "io.logto.android://io.logto.sample/callback"
+        val callbackUri = Uri.parse("io.logto.android://io.logto.sample/callback2?state=state&code=code")
+
+        val logtoAuthSession = LogtoAuthSession(
+            mockk(),
+            mockk(),
+            mockk(),
+            SignInOptions(redirectUri = redirectUri),
+            mockk(),
+        )
+
+        LogtoAuthManager.handleAuthStart(logtoAuthSession)
+        assertThat(LogtoAuthManager.isLogtoAuthResult(callbackUri)).isFalse()
+    }
+
+    @Test
+    fun `isLogtoAuthResult should match redirect URI query parameters`() {
+        val redirectUri = "io.logto.android://io.logto.sample/callback?connector_id=foo"
+        val matchedCallbackUri = Uri.parse("$redirectUri&state=state&code=code")
+        val mismatchedCallbackUri = Uri.parse(
+            "io.logto.android://io.logto.sample/callback?connector_id=bar&state=state&code=code",
+        )
+
+        val logtoAuthSession = LogtoAuthSession(
+            mockk(),
+            mockk(),
+            mockk(),
+            SignInOptions(redirectUri = redirectUri),
+            mockk(),
         )
 
         LogtoAuthManager.handleAuthStart(logtoAuthSession)

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
@@ -115,6 +115,36 @@ class LogtoAuthManagerTest {
     }
 
     @Test
+    fun `isLogtoAuthResult should return false if callback or redirect URI contains fragment`() {
+        val redirectUri = "io.logto.android://io.logto.sample/callback"
+        val callbackUriWithFragment = Uri.parse("$redirectUri?state=state&code=code#fragment")
+
+        val logtoAuthSession = LogtoAuthSession(
+            mockk(),
+            mockk(),
+            mockk(),
+            SignInOptions(redirectUri = redirectUri),
+            mockk(),
+        )
+
+        LogtoAuthManager.handleAuthStart(logtoAuthSession)
+        assertThat(LogtoAuthManager.isLogtoAuthResult(callbackUriWithFragment)).isFalse()
+
+        val redirectUriWithFragment = "$redirectUri#fragment"
+        val fragmentLogtoAuthSession = LogtoAuthSession(
+            mockk(),
+            mockk(),
+            mockk(),
+            SignInOptions(redirectUri = redirectUriWithFragment),
+            mockk(),
+        )
+
+        LogtoAuthManager.handleAuthStart(fragmentLogtoAuthSession)
+        val callbackUri = Uri.parse("$redirectUri?state=state&code=code")
+        assertThat(LogtoAuthManager.isLogtoAuthResult(callbackUri)).isFalse()
+    }
+
+    @Test
     fun `isLogtoAuthResult should return false if no session is provided`() {
         assertThat(LogtoAuthManager.logtoAuthSession).isNull()
         assertThat(LogtoAuthManager.isLogtoAuthResult(mockk())).isFalse()

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSessionTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSessionTest.kt
@@ -128,6 +128,46 @@ class LogtoAuthSessionTest {
     }
 
     @Test
+    fun `should complete with exception with redirectUri fragment`() {
+        val logtoExceptionCapture = mutableListOf<LogtoException?>()
+        val codeTokenResponseCapture = mutableListOf<CodeTokenResponse?>()
+
+        mockkObject(LogtoAuthManager)
+        val mockLogtoConfig: LogtoConfig = mockk()
+        val invalidRedirectUri = "$dummyRedirectUri#fragment"
+        val mockCompletion: Completion<LogtoException, CodeTokenResponse> = mockk()
+        every { mockCompletion.onComplete(any(), any()) } just Runs
+
+        val logtoAuthSession = LogtoAuthSession(
+            mockActivity,
+            mockLogtoConfig,
+            dummyOidcConfigResponse,
+            SignInOptions(redirectUri = invalidRedirectUri),
+            mockCompletion,
+        )
+
+        logtoAuthSession.start()
+
+        verify {
+            mockCompletion.onComplete(
+                captureNullable(logtoExceptionCapture),
+                captureNullable(codeTokenResponseCapture),
+            )
+        }
+
+        assertThat(logtoExceptionCapture.last())
+            .hasMessageThat()
+            .isEqualTo(LogtoException.Type.INVALID_REDIRECT_URI.name)
+        assertThat(codeTokenResponseCapture.last()).isNull()
+
+        verify(exactly = 0) {
+            LogtoAuthManager.handleAuthStart(logtoAuthSession)
+            Core.generateSignInUri(any())
+            mockActivity.startActivity(any())
+        }
+    }
+
+    @Test
     fun `handleCallbackUri should complete with expected results`() {
         val mockCompletion: Completion<LogtoException, CodeTokenResponse> = mockk()
         every { mockCompletion.onComplete(any(), any()) } just Runs

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSessionTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthSessionTest.kt
@@ -44,7 +44,7 @@ class LogtoAuthSessionTest {
         "appId",
     )
 
-    private val dummyRedirectUri = "localhost:3001/callback"
+    private val dummyRedirectUri = "io.logto.android:/callback"
 
     private val dummySignInOptions = SignInOptions(
         redirectUri = dummyRedirectUri
@@ -94,7 +94,7 @@ class LogtoAuthSessionTest {
 
         mockkObject(LogtoAuthManager)
         val mockLogtoConfig: LogtoConfig = mockk()
-        val invalidRedirectUri = ""
+        val invalidRedirectUri = "localhost:3001/callback"
         val mockCompletion: Completion<LogtoException, CodeTokenResponse> = mockk()
         every { mockCompletion.onComplete(any(), any()) } just Runs
 

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
@@ -65,7 +65,7 @@ object CallbackUriUtils {
             )
         }
 
-        if (parsedUri.scheme == null || parsedUri.isOpaque) {
+        if (parsedUri.scheme == null || parsedUri.isOpaque || parsedUri.rawFragment != null) {
             throw CallbackUriVerificationException(
                 CallbackUriVerificationException.Type.INVALID_URI_FORMAT,
             )

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
@@ -2,7 +2,10 @@ package io.logto.sdk.core.util
 
 import io.logto.sdk.core.constant.QueryKey
 import io.logto.sdk.core.exception.CallbackUriVerificationException
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import java.net.URI
+import java.net.URISyntaxException
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 object CallbackUriUtils {
     /**
@@ -18,38 +21,25 @@ object CallbackUriUtils {
         redirectUri: String,
         state: String,
     ): String {
-        // Note: Check scheme
-        if (!callbackUri.startsWith(redirectUri)) {
+        val parsedCallbackUri = parseUri(callbackUri)
+        val parsedRedirectUri = parseUri(redirectUri)
+
+        if (!parsedCallbackUri.matchesRedirectUri(parsedRedirectUri)) {
             throw CallbackUriVerificationException(
                 CallbackUriVerificationException.Type.URI_MISMATCHED,
             )
         }
 
-        // Note: Support custom scheme
-        // TODO - LOG-1487: Replace HttpUrl with More Suitable Utils
-        var validFormatUri = callbackUri
-        if (!callbackUri.startsWith("http")) {
-            if (!callbackUri.contains("://")) {
-                throw CallbackUriVerificationException(CallbackUriVerificationException.Type.INVALID_URI_FORMAT)
-            }
-            validFormatUri = callbackUri.replaceBefore("://", "http")
-        }
-
-        val parsedUri = validFormatUri.toHttpUrlOrNull()
-            ?: throw CallbackUriVerificationException(
-                CallbackUriVerificationException.Type.INVALID_URI_FORMAT,
-            )
-
-        parsedUri.queryParameter(QueryKey.ERROR)?.let {
+        parsedCallbackUri.queryParameters[QueryKey.ERROR]?.let {
             throw CallbackUriVerificationException(
                 CallbackUriVerificationException.Type.ERROR_FOUND_IN_URI,
             ).apply {
                 error = it
-                errorDesc = parsedUri.queryParameter(QueryKey.ERROR_DESCRIPTION)
+                errorDesc = parsedCallbackUri.queryParameters[QueryKey.ERROR_DESCRIPTION]
             }
         }
 
-        parsedUri.queryParameter(QueryKey.STATE)?.let {
+        parsedCallbackUri.queryParameters[QueryKey.STATE]?.let {
             if (it != state) {
                 throw CallbackUriVerificationException(
                     CallbackUriVerificationException.Type.STATE_MISMATCHED,
@@ -59,9 +49,70 @@ object CallbackUriUtils {
             CallbackUriVerificationException.Type.MISSING_STATE_URI_PARAMETER,
         )
 
-        return parsedUri.queryParameter(QueryKey.CODE)
+        return parsedCallbackUri.queryParameters[QueryKey.CODE]
             ?: throw CallbackUriVerificationException(
                 CallbackUriVerificationException.Type.MISSING_CODE_URI_PARAMETER,
             )
+    }
+
+    private fun parseUri(uri: String): ParsedUri {
+        val parsedUri = try {
+            URI(uri)
+        } catch (cause: URISyntaxException) {
+            throw CallbackUriVerificationException(
+                CallbackUriVerificationException.Type.INVALID_URI_FORMAT,
+                cause,
+            )
+        }
+
+        if (parsedUri.scheme == null || parsedUri.rawSchemeSpecificPart?.startsWith("//") != true) {
+            throw CallbackUriVerificationException(
+                CallbackUriVerificationException.Type.INVALID_URI_FORMAT,
+            )
+        }
+
+        return ParsedUri(
+            scheme = parsedUri.scheme,
+            authority = parsedUri.rawAuthority,
+            path = parsedUri.rawPath,
+            queryParameters = parseQueryParameters(parsedUri.rawQuery),
+        )
+    }
+
+    private fun parseQueryParameters(rawQuery: String?): Map<String, String> {
+        if (rawQuery.isNullOrEmpty()) {
+            return emptyMap()
+        }
+
+        return rawQuery.split("&").fold(mutableMapOf()) { queryParameters, parameter ->
+            val separatorIndex = parameter.indexOf("=")
+            val rawName = if (separatorIndex == -1) parameter else parameter.substring(0, separatorIndex)
+            val rawValue = if (separatorIndex == -1) "" else parameter.substring(separatorIndex + 1)
+
+            queryParameters.putIfAbsent(decodeQueryComponent(rawName), decodeQueryComponent(rawValue))
+            queryParameters
+        }
+    }
+
+    private fun decodeQueryComponent(value: String): String = try {
+        URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+    } catch (cause: IllegalArgumentException) {
+        throw CallbackUriVerificationException(
+            CallbackUriVerificationException.Type.INVALID_URI_FORMAT,
+            cause,
+        )
+    }
+
+    private data class ParsedUri(
+        val scheme: String,
+        val authority: String?,
+        val path: String,
+        val queryParameters: Map<String, String>,
+    ) {
+        fun matchesRedirectUri(redirectUri: ParsedUri): Boolean =
+            scheme == redirectUri.scheme &&
+                authority == redirectUri.authority &&
+                path == redirectUri.path &&
+                redirectUri.queryParameters.all { (key, value) -> queryParameters[key] == value }
     }
 }

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
@@ -7,6 +7,9 @@ import java.net.URISyntaxException
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
+private const val PERCENT_ENCODED_CHARACTER_LENGTH = 3
+private const val HEX_RADIX = 16
+
 object CallbackUriUtils {
     /**
      * Verify and parse code from callback URI
@@ -72,9 +75,9 @@ object CallbackUriUtils {
         }
 
         return ParsedUri(
-            scheme = parsedUri.scheme,
-            authority = parsedUri.rawAuthority,
-            path = parsedUri.rawPath.orEmpty(),
+            scheme = parsedUri.scheme.lowercase(),
+            authority = normalizeAuthority(parsedUri),
+            path = normalizePath(parsedUri.rawPath.orEmpty()),
             queryParameters = parseQueryParameters(parsedUri.rawQuery),
         )
     }
@@ -88,10 +91,78 @@ object CallbackUriUtils {
             val separatorIndex = parameter.indexOf("=")
             val rawName = if (separatorIndex == -1) parameter else parameter.substring(0, separatorIndex)
             val rawValue = if (separatorIndex == -1) "" else parameter.substring(separatorIndex + 1)
+            val name = decodeQueryComponent(rawName)
 
-            queryParameters.putIfAbsent(decodeQueryComponent(rawName), decodeQueryComponent(rawValue))
+            if (queryParameters.containsKey(name)) {
+                throw CallbackUriVerificationException(
+                    CallbackUriVerificationException.Type.INVALID_URI_FORMAT,
+                )
+            }
+
+            queryParameters[name] = decodeQueryComponent(rawValue)
             queryParameters
         }
+    }
+
+    private fun normalizeAuthority(uri: URI): String? {
+        if (uri.rawAuthority == null) {
+            return null
+        }
+
+        uri.host?.let { host ->
+            val userInfo = uri.rawUserInfo?.let { "$it@" }.orEmpty()
+            val port = if (uri.port == -1) "" else ":${uri.port}"
+            return "$userInfo${host.lowercase()}$port"
+        }
+
+        return uri.rawAuthority.lowercase()
+    }
+
+    private fun normalizePath(path: String): String = normalizePercentEncodedUnreserved(path)
+
+    private fun normalizePercentEncodedUnreserved(value: String): String {
+        val normalizedValue = StringBuilder()
+        var index = 0
+
+        while (index < value.length) {
+            val normalizedCharacter = value.normalizedPercentEncodedCharacterAt(index)
+            if (normalizedCharacter != null) {
+                normalizedValue.append(normalizedCharacter)
+                index += PERCENT_ENCODED_CHARACTER_LENGTH
+                continue
+            }
+
+            normalizedValue.append(value[index])
+            index += 1
+        }
+
+        return normalizedValue.toString()
+    }
+
+    private fun String.normalizedPercentEncodedCharacterAt(index: Int): String? {
+        if (this[index] != '%' || index + PERCENT_ENCODED_CHARACTER_LENGTH > length) {
+            return null
+        }
+
+        val hex = substring(index + 1, index + PERCENT_ENCODED_CHARACTER_LENGTH)
+        val char = hex.toIntOrNull(HEX_RADIX)?.toChar() ?: return null
+        return if (char.isUnreservedUriCharacter()) {
+            char.toString()
+        } else {
+            "%${hex.uppercase()}"
+        }
+    }
+
+    private fun Char.isUnreservedUriCharacter(): Boolean = when (this) {
+        in 'A'..'Z',
+        in 'a'..'z',
+        in '0'..'9',
+        '-',
+        '.',
+        '_',
+        '~',
+        -> true
+        else -> false
     }
 
     private fun decodeQueryComponent(value: String): String = try {

--- a/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
+++ b/kotlin-sdk/kotlin/src/main/kotlin/io/logto/sdk/core/util/CallbackUriUtils.kt
@@ -65,7 +65,7 @@ object CallbackUriUtils {
             )
         }
 
-        if (parsedUri.scheme == null || parsedUri.rawSchemeSpecificPart?.startsWith("//") != true) {
+        if (parsedUri.scheme == null || parsedUri.isOpaque) {
             throw CallbackUriVerificationException(
                 CallbackUriVerificationException.Type.INVALID_URI_FORMAT,
             )
@@ -74,7 +74,7 @@ object CallbackUriUtils {
         return ParsedUri(
             scheme = parsedUri.scheme,
             authority = parsedUri.rawAuthority,
-            path = parsedUri.rawPath,
+            path = parsedUri.rawPath.orEmpty(),
             queryParameters = parseQueryParameters(parsedUri.rawQuery),
         )
     }

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
@@ -29,6 +29,30 @@ class CallbackUriUtilsTest {
     }
 
     @Test
+    fun `verifyAndParseCodeFromCallbackUri should get expected code from custom scheme URI without authority`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "io.logto.android:/callback"
+        val callbackUri = "io.logto.android:/callback?state=$state&code=$code"
+
+        val resultCode = CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+
+        assertThat(resultCode).isEqualTo(code)
+    }
+
+    @Test
+    fun `verifyAndParseCodeFromCallbackUri should get expected code from custom scheme URI without path`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "io.logto.android://io.logto.sample"
+        val callbackUri = "io.logto.android://io.logto.sample?state=$state&code=$code"
+
+        val resultCode = CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+
+        assertThat(resultCode).isEqualTo(code)
+    }
+
+    @Test
     fun `verifyAndParseCodeFromCallbackUri should decode query parameters`() {
         val state = "test state"
         val code = "test/code"
@@ -107,6 +131,21 @@ class CallbackUriUtilsTest {
     }
 
     @Test
+    fun `verifyAndParseCodeFromCallbackUri should throw with opaque URI`() {
+        val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
+            CallbackUriUtils.verifyAndParseCodeFromCallbackUri(
+                "io.logto.android:callback",
+                "io.logto.android:callback",
+                "dummyState",
+            )
+        }
+
+        assertThat(expectedException)
+            .hasMessageThat()
+            .contains(CallbackUriVerificationException.Type.INVALID_URI_FORMAT.name)
+    }
+
+    @Test
     fun `verifyAndParseCodeFromCallbackUri should throw with error parameter`() {
         val state = GenerateUtils.generateState()
         val code = "dummyCode"
@@ -126,8 +165,8 @@ class CallbackUriUtilsTest {
     fun `verifyAndParseCodeFromCallbackUri should throw with error desc with both error and errorDesc parameter`() {
         val state = GenerateUtils.generateState()
         val code = "dummyCode"
-        val errorDesc = "you hava an error description"
-        val encodedErrorDesc = "you%20hava%20an%20error%20description"
+        val errorDesc = "you have an error description"
+        val encodedErrorDesc = "you%20have%20an%20error%20description"
         val error = "error"
         val redirectUri = "https://myapp.com/callback"
         val callbackUri = "https://myapp.com/callback" +

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
@@ -146,6 +146,38 @@ class CallbackUriUtilsTest {
     }
 
     @Test
+    fun `verifyAndParseCodeFromCallbackUri should throw if callback URI contains fragment`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "https://myapp.com/callback"
+        val callbackUri = "https://myapp.com/callback?state=$state&code=$code#fragment"
+
+        val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
+            CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+        }
+
+        assertThat(expectedException)
+            .hasMessageThat()
+            .contains(CallbackUriVerificationException.Type.INVALID_URI_FORMAT.name)
+    }
+
+    @Test
+    fun `verifyAndParseCodeFromCallbackUri should throw if redirect URI contains fragment`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "https://myapp.com/callback#fragment"
+        val callbackUri = "https://myapp.com/callback?state=$state&code=$code"
+
+        val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
+            CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+        }
+
+        assertThat(expectedException)
+            .hasMessageThat()
+            .contains(CallbackUriVerificationException.Type.INVALID_URI_FORMAT.name)
+    }
+
+    @Test
     fun `verifyAndParseCodeFromCallbackUri should throw with error parameter`() {
         val state = GenerateUtils.generateState()
         val code = "dummyCode"

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
@@ -29,6 +29,18 @@ class CallbackUriUtilsTest {
     }
 
     @Test
+    fun `verifyAndParseCodeFromCallbackUri should decode query parameters`() {
+        val state = "test state"
+        val code = "test/code"
+        val redirectUri = "https://myapp.com/callback"
+        val callbackUri = "https://myapp.com/callback?state=test%20state&code=test%2Fcode"
+
+        val resultCode = CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+
+        assertThat(resultCode).isEqualTo(code)
+    }
+
+    @Test
     fun `verifyAndParseCodeFromCallbackUri should throw with mismatched URI`() {
         val state = GenerateUtils.generateState()
         val code = "testCode"
@@ -42,6 +54,34 @@ class CallbackUriUtilsTest {
         assertThat(expectedException)
             .hasMessageThat()
             .contains(CallbackUriVerificationException.Type.URI_MISMATCHED.name)
+    }
+
+    @Test
+    fun `verifyAndParseCodeFromCallbackUri should throw when callback path is only a prefix match`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "https://myapp.com/callback"
+        val callbackUri = "https://myapp.com/callback2?state=$state&code=$code"
+
+        val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
+            CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+        }
+
+        assertThat(expectedException)
+            .hasMessageThat()
+            .contains(CallbackUriVerificationException.Type.URI_MISMATCHED.name)
+    }
+
+    @Test
+    fun `verifyAndParseCodeFromCallbackUri should match redirect URI query parameters`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "https://myapp.com/callback?connector_id=foo"
+        val callbackUri = "https://myapp.com/callback?connector_id=foo&state=$state&code=$code"
+
+        val resultCode = CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+
+        assertThat(resultCode).isEqualTo(code)
     }
 
     @Test
@@ -87,9 +127,11 @@ class CallbackUriUtilsTest {
         val state = GenerateUtils.generateState()
         val code = "dummyCode"
         val errorDesc = "you hava an error description"
+        val encodedErrorDesc = "you%20hava%20an%20error%20description"
         val error = "error"
         val redirectUri = "https://myapp.com/callback"
-        val callbackUri = "https://myapp.com/callback?error_description=$errorDesc&error=$error&state=$state&code=$code"
+        val callbackUri = "https://myapp.com/callback" +
+            "?error_description=$encodedErrorDesc&error=$error&state=$state&code=$code"
 
         val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
             CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)

--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/util/CallbackUriUtilsTest.kt
@@ -109,6 +109,18 @@ class CallbackUriUtilsTest {
     }
 
     @Test
+    fun `verifyAndParseCodeFromCallbackUri should normalize URI scheme host and path`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "https://MYAPP.com/callback%7E"
+        val callbackUri = "HTTPS://myapp.com/callback~?state=$state&code=$code"
+
+        val resultCode = CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
+
+        assertThat(resultCode).isEqualTo(code)
+    }
+
+    @Test
     fun `verifyAndParseCodeFromCallbackUriShould throw with empty URI`() {
         val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
             CallbackUriUtils.verifyAndParseCodeFromCallbackUri("", "", "dummyState")
@@ -123,6 +135,22 @@ class CallbackUriUtilsTest {
     fun `verifyAndParseCodeFromCallbackUri should throw with invalid URI format`() {
         val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
             CallbackUriUtils.verifyAndParseCodeFromCallbackUri("invalidUri", "invalidUri", "dummyState")
+        }
+
+        assertThat(expectedException)
+            .hasMessageThat()
+            .contains(CallbackUriVerificationException.Type.INVALID_URI_FORMAT.name)
+    }
+
+    @Test
+    fun `verifyAndParseCodeFromCallbackUri should throw with duplicate query parameters`() {
+        val state = GenerateUtils.generateState()
+        val code = "testCode"
+        val redirectUri = "https://myapp.com/callback"
+        val callbackUri = "https://myapp.com/callback?state=$state&state=anotherState&code=$code"
+
+        val expectedException = Assert.assertThrows(CallbackUriVerificationException::class.java) {
+            CallbackUriUtils.verifyAndParseCodeFromCallbackUri(callbackUri, redirectUri, state)
         }
 
         assertThat(expectedException)


### PR DESCRIPTION
## Summary
- replace OkHttp HttpUrl usage in callback URI parsing with URI-based parsing that supports custom schemes
- compare callback and redirect URIs structurally instead of using string prefix matching
- add Kotlin and Android tests for custom schemes, query decoding, redirect query matching, and path prefix mismatches

## Tests
- ./gradlew -p kotlin-sdk :kotlin:test
- JAVA_HOME=/Library/Java/JavaVirtualMachines/microsoft-11.jdk/Contents/Home ./gradlew -p android-sdk --include-build ../android-social :android:testDebugUnitTest --tests io.logto.sdk.android.auth.logto.LogtoAuthManagerTest