### PR TITLE
fix(core): exercise fetchJwksJson in its failure-path test

### DIFF
--- a/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreFetchTest.kt
+++ b/kotlin-sdk/kotlin/src/test/kotlin/io/logto/sdk/core/CoreFetchTest.kt
@@ -189,10 +189,10 @@ class CoreFetchTest {
     @Test
     fun `fetchJwksJson should fail without response`() {
         var throwableReceiver: Throwable? = null
-        var responseReceiver: OidcConfigResponse? = null
+        var responseReceiver: String? = null
 
         val countDownLatch = CountDownLatch(1)
-        Core.fetchOidcConfig(
+        Core.fetchJwksJson(
             "${mockWebServer.url("/jwks:bad")}",
         ) { throwable, response ->
             throwableReceiver = throwable


### PR DESCRIPTION
## Summary
- The test `fetchJwksJson should fail without response` was calling `Core.fetchOidcConfig` (with an `OidcConfigResponse?` receiver), so the JWKS failure path was never actually exercised. Fix the body to call `Core.fetchJwksJson` and capture a `String?` response, matching the rest of the JWKS suite.

## Testing
- `./gradlew -p kotlin-sdk :kotlin:test --tests 'io.logto.sdk.core.CoreFetchTest.fetchJwksJson should fail without response'`

## Checklist

- [ ] unit tests
- [ ] integration tests