### PR TITLE
ci: use BOT_PAT so release PRs trigger workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:


### PR DESCRIPTION
## Summary
- Replace `secrets.GITHUB_TOKEN` with `secrets.BOT_PAT` in the release-please action so release PRs trigger `main.yml` and `commitlint.yml` (PRs opened with the default `GITHUB_TOKEN` cannot start workflow runs by GitHub design, which is why #245 has zero CI runs).
- Aligns this repo with `logto-io/js`, which already uses `BOT_PAT` for its publish workflow.

## Testing
N/A — verifiable by observing CI runs on the next release-please PR after this lands.

## Checklist

- [ ] unit tests
- [ ] integration tests