### PR TITLE
fix(android-sdk): clear local credentials eagerly on browser sign-out

### DIFF
--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -196,10 +196,12 @@ open class LogtoClient(
     /**
      * Sign out and end the session on the Logto server.
      *
-     * The end session endpoint is opened in the browser, and the user is navigated back
-     * to the app through the [postLogoutRedirectUri]. Local credentials are cleared and
-     * the refresh token is revoked before the browser opens, so the local session always
-     * ends even if the browser flow is abandoned.
+     * Local credentials are cleared as soon as the sign-out starts, so the local session
+     * always ends even if fetching the OIDC config fails or the browser flow is abandoned.
+     *
+     * The refresh token is revoked before the end session endpoint is opened in the
+     * browser, and the user is navigated back to the app through the
+     * [postLogoutRedirectUri].
      *
      * An invalid [postLogoutRedirectUri] is reported as
      * [LogtoException.Type.INVALID_REDIRECT_URI] without opening the browser; local
@@ -225,28 +227,47 @@ open class LogtoClient(
             return
         }
 
+        val tokenToRevoke = refreshToken
+        accessTokenMap.clear()
+        idToken = null
+        refreshToken = null
+
         getOidcConfig { getOidcConfigException, oidcConfig ->
             getOidcConfigException?.let {
                 completion?.onComplete(it)
                 return@getOidcConfig
             }
 
-            val signOutUri = Core.generateSignOutUri(
-                endSessionEndpoint = requireNotNull(oidcConfig).endSessionEndpoint,
-                clientId = logtoConfig.appId,
-                postLogoutRedirectUri = postLogoutRedirectUri,
-            )
+            val fetchedOidcConfig = requireNotNull(oidcConfig)
 
-            signOut { revokeException ->
+            fun startBrowserSignOut(revokeException: LogtoException?) {
                 val signOutSession = LogtoSignOutSession(
                     context = context,
-                    signOutUri = signOutUri,
+                    signOutUri = Core.generateSignOutUri(
+                        endSessionEndpoint = fetchedOidcConfig.endSessionEndpoint,
+                        clientId = logtoConfig.appId,
+                        postLogoutRedirectUri = postLogoutRedirectUri,
+                    ),
                     postLogoutRedirectUri = postLogoutRedirectUri,
                 ) { browserException ->
                     completion?.onComplete(browserException ?: revokeException)
                 }
                 signOutSession.start()
             }
+
+            tokenToRevoke?.let { token ->
+                Core.revoke(
+                    revocationEndpoint = fetchedOidcConfig.revocationEndpoint,
+                    clientId = logtoConfig.appId,
+                    token = token,
+                ) { revocationException ->
+                    startBrowserSignOut(
+                        revocationException?.let {
+                            LogtoException(LogtoException.Type.UNABLE_TO_REVOKE_TOKEN, it)
+                        },
+                    )
+                }
+            } ?: startBrowserSignOut(null)
         }
     }
 

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
@@ -1,6 +1,9 @@
 package io.logto.sdk.android
 
+import android.app.Activity
+import android.net.Uri
 import com.google.common.truth.Truth.assertThat
+import io.logto.sdk.android.auth.logto.LogtoAuthManager
 import io.logto.sdk.android.auth.logto.LogtoAuthSession
 import io.logto.sdk.android.auth.logto.LogtoSignOutSession
 import io.logto.sdk.android.completion.Completion
@@ -32,6 +35,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 class LogtoClientTest {
     private val oidcConfigResponseMock: OidcConfigResponse = mockk()
@@ -82,6 +86,7 @@ class LogtoClientTest {
     @After
     fun tearDown() {
         clearAllMocks()
+        LogtoAuthManager.browserSession = null
     }
 
     @Test
@@ -323,6 +328,173 @@ class LogtoClientTest {
             anyConstructed<LogtoSignOutSession>().start()
         }
 
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun `signOut with postLogoutRedirectUri should clear local data even if get oidc config failed`() {
+        logtoClient = LogtoClient(logtoConfigMock, mockk())
+
+        mockkObject(logtoClient)
+
+        logtoClient.setupRefreshToken(TEST_REFRESH_TOKEN)
+        logtoClient.setupIdToken(TEST_ID_TOKEN)
+
+        every { logtoClient.getOidcConfig(any()) } answers {
+            lastArg<Completion<LogtoException, OidcConfigResponse>>().onComplete(
+                LogtoException(LogtoException.Type.UNABLE_TO_FETCH_OIDC_CONFIG),
+                null,
+            )
+        }
+
+        val completionResults = mutableListOf<LogtoException?>()
+        logtoClient.signOut(mockk(), "io.logto.android://io.logto.sample/callback") {
+            completionResults.add(it)
+        }
+
+        assertThat(completionResults).hasSize(1)
+        assertThat(completionResults.last())
+            .hasMessageThat()
+            .isEqualTo(LogtoException.Type.UNABLE_TO_FETCH_OIDC_CONFIG.name)
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun `signOut with postLogoutRedirectUri should report the revoke exception after the browser flow settles`() {
+        every { logtoConfigMock.appId } returns TEST_APP_ID
+
+        logtoClient = LogtoClient(logtoConfigMock, mockk())
+
+        mockkObject(logtoClient)
+
+        logtoClient.setupRefreshToken(TEST_REFRESH_TOKEN)
+        logtoClient.setupIdToken(TEST_ID_TOKEN)
+
+        every { oidcConfigResponseMock.endSessionEndpoint } returns TEST_END_SESSION_ENDPOINT
+        every { oidcConfigResponseMock.revocationEndpoint } returns TEST_REVOCATION_ENDPOINT
+        every { logtoClient.getOidcConfig(any()) } answers {
+            lastArg<Completion<LogtoException, OidcConfigResponse>>().onComplete(
+                null,
+                oidcConfigResponseMock,
+            )
+        }
+
+        mockkObject(Core)
+        every { Core.revoke(any(), any(), any(), any()) } answers {
+            lastArg<HttpEmptyCompletion>().onComplete(LogtoException(LogtoException.Type.UNABLE_TO_REVOKE_TOKEN))
+        }
+
+        val mockActivity: Activity = mockk()
+        every { mockActivity.packageName } returns "logto.test"
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val completionResults = mutableListOf<LogtoException?>()
+        logtoClient.signOut(mockActivity, "io.logto.android://io.logto.sample/callback") {
+            completionResults.add(it)
+        }
+
+        // The revoke has already failed, but the completion should wait for the browser flow
+        assertThat(completionResults).isEmpty()
+
+        LogtoAuthManager.handleCallbackUri(Uri.parse("io.logto.android://io.logto.sample/callback"))
+
+        assertThat(completionResults).hasSize(1)
+        assertThat(completionResults.last())
+            .hasMessageThat()
+            .isEqualTo(LogtoException.Type.UNABLE_TO_REVOKE_TOKEN.name)
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun `signOut with postLogoutRedirectUri should open the browser only after the revocation settles`() {
+        every { logtoConfigMock.appId } returns TEST_APP_ID
+
+        logtoClient = LogtoClient(logtoConfigMock, mockk())
+
+        mockkObject(logtoClient)
+
+        logtoClient.setupRefreshToken(TEST_REFRESH_TOKEN)
+        logtoClient.setupIdToken(TEST_ID_TOKEN)
+
+        every { oidcConfigResponseMock.endSessionEndpoint } returns TEST_END_SESSION_ENDPOINT
+        every { oidcConfigResponseMock.revocationEndpoint } returns TEST_REVOCATION_ENDPOINT
+        every { logtoClient.getOidcConfig(any()) } answers {
+            lastArg<Completion<LogtoException, OidcConfigResponse>>().onComplete(
+                null,
+                oidcConfigResponseMock,
+            )
+        }
+
+        val revokeCompletions = mutableListOf<HttpEmptyCompletion>()
+        mockkObject(Core)
+        every { Core.revoke(any(), any(), any(), any()) } answers {
+            revokeCompletions.add(lastArg())
+        }
+
+        val mockActivity: Activity = mockk()
+        every { mockActivity.packageName } returns "logto.test"
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val completionResults = mutableListOf<LogtoException?>()
+        logtoClient.signOut(mockActivity, "io.logto.android://io.logto.sample/callback") {
+            completionResults.add(it)
+        }
+
+        // The revocation is still pending, so the browser flow should not start yet
+        verify(exactly = 0) { mockActivity.startActivity(any()) }
+
+        revokeCompletions.last().onComplete(null)
+
+        verify { mockActivity.startActivity(any()) }
+        assertThat(completionResults).isEmpty()
+
+        LogtoAuthManager.handleCallbackUri(Uri.parse("io.logto.android://io.logto.sample/callback"))
+
+        assertThat(completionResults).hasSize(1)
+        assertThat(completionResults.last()).isNull()
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun `signOut with postLogoutRedirectUri should prioritize the browser exception when both flows fail`() {
+        every { logtoConfigMock.appId } returns TEST_APP_ID
+
+        logtoClient = LogtoClient(logtoConfigMock, mockk())
+
+        mockkObject(logtoClient)
+
+        logtoClient.setupRefreshToken(TEST_REFRESH_TOKEN)
+        logtoClient.setupIdToken(TEST_ID_TOKEN)
+
+        every { oidcConfigResponseMock.endSessionEndpoint } returns TEST_END_SESSION_ENDPOINT
+        every { oidcConfigResponseMock.revocationEndpoint } returns TEST_REVOCATION_ENDPOINT
+        every { logtoClient.getOidcConfig(any()) } answers {
+            lastArg<Completion<LogtoException, OidcConfigResponse>>().onComplete(
+                null,
+                oidcConfigResponseMock,
+            )
+        }
+
+        mockkObject(Core)
+        every { Core.revoke(any(), any(), any(), any()) } answers {
+            lastArg<HttpEmptyCompletion>().onComplete(LogtoException(LogtoException.Type.UNABLE_TO_REVOKE_TOKEN))
+        }
+
+        val mockActivity: Activity = mockk()
+        every { mockActivity.packageName } returns "logto.test"
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val completionResults = mutableListOf<LogtoException?>()
+        logtoClient.signOut(mockActivity, "io.logto.android://io.logto.sample/callback") {
+            completionResults.add(it)
+        }
+
+        LogtoAuthManager.handleUserCancel()
+
+        assertThat(completionResults).hasSize(1)
+        assertThat(completionResults.last())
+            .hasMessageThat()
+            .isEqualTo(LogtoException.Type.USER_CANCELED.name)
         assertThat(logtoClient.isAuthenticated).isFalse()
     }
 


### PR DESCRIPTION
## Summary

A flow fix to the browser-based `signOut(context, postLogoutRedirectUri)` introduced in #249:

- **Clear local credentials eagerly.** Previously the local credentials were only cleared after the OIDC config was fetched, so an offline user (or a cold start with no cached config) could not sign out at all — contradicting the documented "the local session always ends" guarantee. Local credentials are now cleared synchronously at the start of the sign-out, before any network request.

The rest of the flow is unchanged: the refresh token is revoked first, then the end session endpoint is opened in the browser, and the browser exception still takes priority over the revoke exception when both fail (now pinned by a dedicated unit test).

## Testing

unit tests

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [x] unit tests
- [ ] integration tests (N/A)
- [x] necessary KDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
