### PR TITLE
feat(android-sdk)!: revamp the sign-out API

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -75,10 +75,10 @@ on Maven Central and receives fixes on the `v2.x` line.
 ## Changed: sign-out API
 
 In v3, `signOut` performs a complete sign-out: it clears local credentials, revokes the
-refresh token, and ends the session on the Logto server by opening the end session
-endpoint in the browser. Local credentials are always cleared; the remote steps are
-best-effort and need the OIDC config to be reachable — any failure is reported through
-the completion.
+refresh token (when one is present), and ends the session on the Logto server by opening
+the end session endpoint in the browser. Local credentials are always cleared; the remote
+steps are best-effort and need the OIDC config to be reachable — any failure is reported
+through the completion.
 
 ```kotlin
 // The browser opens briefly and navigates back to the app through the post sign-out

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -72,23 +72,35 @@ provider apps via their universal/app links) now happens in the browser, like on
 If you depend on WeChat/Alipay **native SDK** sign-in, stay on v2 — it remains available
 on Maven Central and receives fixes on the `v2.x` line.
 
-## Changed: sign-out behavior
+## Changed: sign-out API
 
-`signOut(completion)` still clears local credentials and revokes the refresh token, but it
-can no longer clear the session cookie — that cookie now lives in the browser, which the
-app cannot touch. After a local-only sign-out, the next `signIn` may silently re-enter the
-account through the existing browser session.
-
-To also end the session on the Logto server, use the new overload, which opens the end
-session endpoint in the browser and returns through your post sign-out redirect URI
-(register it in the Logto console first; its scheme must also match
-`logtoRedirectScheme`):
+In v3, `signOut` performs a complete sign-out: it clears local credentials, revokes the
+refresh token, and ends the session on the Logto server by opening the end session
+endpoint in the browser.
 
 ```kotlin
+// The browser opens briefly and navigates back to the app through the post sign-out
+// redirect URI (register it in the Logto console first; its scheme must also match
+// `logtoRedirectScheme`):
 logtoClient.signOut(this, "io.logto.android://io.logto.sample/callback") { exception ->
     // ...
 }
+
+// Or omit the URI — no console configuration needed; the browser shows the Logto
+// sign-out page and the user dismisses it manually:
+logtoClient.signOut(this)
 ```
+
+Dismissing the browser during sign-out is not reported as an error: local credentials
+are cleared and the refresh token is revoked before the browser opens, so the sign-out
+has already taken effect.
+
+The v2 `signOut(completion)` is renamed to `clearCredentials(completion)` with unchanged
+behavior: it clears local credentials and revokes the refresh token, but it cannot clear
+the session cookie — that cookie now lives in the browser, which the app cannot touch.
+After clearing credentials, the next `signIn` may silently re-enter the account through
+the existing browser session. Prefer `signOut`; use `clearCredentials` when no UI context
+is available (e.g. forcing a local sign-out from a background error handler).
 
 ## Other breaking changes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -76,7 +76,9 @@ on Maven Central and receives fixes on the `v2.x` line.
 
 In v3, `signOut` performs a complete sign-out: it clears local credentials, revokes the
 refresh token, and ends the session on the Logto server by opening the end session
-endpoint in the browser.
+endpoint in the browser. Local credentials are always cleared; the remote steps are
+best-effort and need the OIDC config to be reachable — any failure is reported through
+the completion.
 
 ```kotlin
 // The browser opens briefly and navigates back to the app through the post sign-out
@@ -91,9 +93,10 @@ logtoClient.signOut(this, "io.logto.android://io.logto.sample/callback") { excep
 logtoClient.signOut(this)
 ```
 
-Dismissing the browser during sign-out is not reported as an error: local credentials
-are cleared and the refresh token is revoked before the browser opens, so the sign-out
-has already taken effect.
+Dismissing the browser during sign-out is never reported as `USER_CANCELED`: local
+credentials are cleared and the token revocation has settled before the browser opens,
+so the sign-out has already taken effect. Failures of the earlier steps (such as a
+failed revocation) are still reported through the completion.
 
 The v2 `signOut(completion)` is renamed to `clearCredentials(completion)` with unchanged
 behavior: it clears local credentials and revokes the refresh token, but it cannot clear

--- a/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/fragment/TokenFragment.kt
+++ b/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/fragment/TokenFragment.kt
@@ -45,6 +45,14 @@ class TokenFragment : Fragment() {
         view.findViewById<Button>(R.id.sign_out_button).setOnClickListener {
             logtoViewModel.signOut(requireActivity())
         }
+
+        view.findViewById<Button>(R.id.sign_out_without_redirect_button).setOnClickListener {
+            logtoViewModel.signOutWithoutRedirect(requireActivity())
+        }
+
+        view.findViewById<Button>(R.id.clear_credentials_button).setOnClickListener {
+            logtoViewModel.clearCredentials()
+        }
     }
 
     private fun initViewModel() {

--- a/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/viewmodel/LogtoViewModel.kt
+++ b/android-sample-kotlin/app/src/main/kotlin/io/logto/android/sample4k/viewmodel/LogtoViewModel.kt
@@ -45,13 +45,36 @@ class LogtoViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    // Complete sign-out: clears local credentials AND ends the session on the Logto server
+    // through the browser. With a post sign-out redirect URI, the browser navigates back to
+    // the app automatically (register the URI in the Logto console first).
     fun signOut(context: Activity) {
-        // Ends the session on the Logto server through the browser; local credentials are
-        // cleared even if the browser flow is abandoned.
         logtoClient.signOut(context, "io.logto.android://io.logto.android.sample4k/callback") {
-            it?.let { _logtoException.postValue(it) }
-            _authenticated.postValue(logtoClient.isAuthenticated)
+            handleSignOutResult(it)
         }
+    }
+
+    // Complete sign-out as well — same effect on the server session as the one above. The
+    // only difference is UX: without a redirect URI the browser shows the Logto sign-out
+    // page and the user returns by dismissing it manually (no console configuration needed).
+    fun signOutWithoutRedirect(context: Activity) {
+        logtoClient.signOut(context) {
+            handleSignOutResult(it)
+        }
+    }
+
+    // Local sign-out only: clears the cached tokens and revokes the refresh token, but does
+    // NOT end the session on the Logto server (no browser is opened). The session cookie
+    // stays in the browser, so the next signIn may silently sign back in via SSO.
+    fun clearCredentials() {
+        logtoClient.clearCredentials {
+            handleSignOutResult(it)
+        }
+    }
+
+    private fun handleSignOutResult(exception: LogtoException?) {
+        exception?.let { _logtoException.postValue(it) }
+        _authenticated.postValue(logtoClient.isAuthenticated)
     }
 
     fun getAccessToken() {

--- a/android-sample-kotlin/app/src/main/res/layout/fragment_token.xml
+++ b/android-sample-kotlin/app/src/main/res/layout/fragment_token.xml
@@ -7,40 +7,67 @@
     android:background="#141222"
     tools:context=".fragment.TokenFragment">
 
-    <TextView
-        android:id="@+id/token_claims_text"
+    <ScrollView
+        android:id="@+id/token_claims_scroll"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="32dp"
-        android:layout_marginTop="150dp"
+        android:layout_marginTop="48dp"
         android:layout_marginEnd="32dp"
-        android:layout_marginBottom="250dp"
-        android:textAlignment="viewStart"
-        android:textColor="#ffffff"
-        android:textSize="18sp"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toTopOf="@+id/button_container"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/token_claims_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAlignment="viewStart"
+            android:textColor="#ffffff"
+            android:textSize="18sp" />
+
+    </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/button_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent">
 
-    <Button
-        android:id="@+id/get_access_token_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="30dp"
-        android:text="@string/get_access_token_button"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/token_claims_text" />
+        <Button
+            android:id="@+id/get_access_token_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/get_access_token_button" />
 
-    <Button
-        android:id="@+id/sign_out_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="30dp"
-        android:text="@string/sign_out_button"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/get_access_token_button" />
+        <Button
+            android:id="@+id/sign_out_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/sign_out_button" />
+
+        <Button
+            android:id="@+id/sign_out_without_redirect_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/sign_out_without_redirect_button" />
+
+        <Button
+            android:id="@+id/clear_credentials_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/clear_credentials_button" />
+
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-sample-kotlin/app/src/main/res/values/strings.xml
+++ b/android-sample-kotlin/app/src/main/res/values/strings.xml
@@ -3,5 +3,7 @@
     <string name="logto_logo_desc">logto logo</string>
     <string name="sign_in_button">Sign In</string>
     <string name="get_access_token_button">Get Access Token</string>
-    <string name="sign_out_button">Sign Out</string>
+    <string name="sign_out_button">Sign Out (Ends Logto Session)</string>
+    <string name="sign_out_without_redirect_button">Sign Out, No Redirect Back (Ends Logto Session)</string>
+    <string name="clear_credentials_button">Sign Out Locally (Keeps Logto Session)</string>
 </resources>

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -152,17 +152,19 @@ open class LogtoClient(
     )
 
     /**
-     * Sign out
+     * Clear local credentials: drop the cached access tokens and the ID token, and revoke
+     * the refresh token.
      *
-     * Local credentials will be cleared even though there are errors occurred when signing out.
+     * Local credentials will be cleared even though there are errors occurred when revoking.
      *
-     * Note: the session in the browser is kept since the browser cookies are not accessible
-     * to the app. Use the [signOut] overload with a `postLogoutRedirectUri` to also end
-     * the session on the Logto server.
+     * Note: this does NOT end the session on the Logto server — the session cookie lives in
+     * the browser, which is not accessible to the app, so the next [signIn] may silently
+     * re-enter the account through the existing browser session. Use [signOut] for a
+     * complete sign-out.
      *
-     * @param[completion] the completion which handles the error occurred when signing out
+     * @param[completion] the completion which handles the error occurred when clearing
      */
-    fun signOut(completion: EmptyCompletion<LogtoException>? = null) {
+    fun clearCredentials(completion: EmptyCompletion<LogtoException>? = null) {
         if (!isAuthenticated) {
             completion?.onComplete(LogtoException(LogtoException.Type.NOT_AUTHENTICATED))
             return
@@ -194,27 +196,33 @@ open class LogtoClient(
     }
 
     /**
-     * Sign out and end the session on the Logto server.
+     * Sign out: clear local credentials, revoke the refresh token, and end the session
+     * on the Logto server by opening the end session endpoint in the browser.
      *
      * Local credentials are cleared as soon as the sign-out starts, so the local session
      * always ends even if fetching the OIDC config fails or the browser flow is abandoned.
      *
      * The refresh token is revoked before the end session endpoint is opened in the
-     * browser, and the user is navigated back to the app through the
-     * [postLogoutRedirectUri].
+     * browser. When [postLogoutRedirectUri] is provided, the browser navigates back to
+     * the app through it after the session ends — register the URI in the Logto console
+     * first; its scheme must match the `logtoRedirectScheme` manifest placeholder. When
+     * omitted, the browser shows the Logto sign-out page and the user dismisses it
+     * manually.
+     *
+     * Dismissing the browser is not reported as an error: the local credentials are
+     * cleared and the refresh token is revoked regardless of how the browser flow ends.
      *
      * An invalid [postLogoutRedirectUri] is reported as
      * [LogtoException.Type.INVALID_REDIRECT_URI] without opening the browser; local
      * credentials are still cleared and the refresh token is revoked.
      *
      * @param[context] the activity to perform the sign-out action
-     * @param[postLogoutRedirectUri] one of the post sign-out redirect URIs of this application;
-     * its scheme must match the `logtoRedirectScheme` manifest placeholder
+     * @param[postLogoutRedirectUri] one of the post sign-out redirect URIs of this application
      * @param[completion] the completion which handles the error occurred when signing out
      */
     fun signOut(
         context: Activity,
-        postLogoutRedirectUri: String,
+        postLogoutRedirectUri: String? = null,
         completion: EmptyCompletion<LogtoException>? = null,
     ) {
         if (!isAuthenticated) {
@@ -222,8 +230,8 @@ open class LogtoClient(
             return
         }
 
-        if (!isValidRedirectUri(postLogoutRedirectUri)) {
-            signOut { completion?.onComplete(LogtoException(LogtoException.Type.INVALID_REDIRECT_URI)) }
+        if (postLogoutRedirectUri != null && !isValidRedirectUri(postLogoutRedirectUri)) {
+            clearCredentials { completion?.onComplete(LogtoException(LogtoException.Type.INVALID_REDIRECT_URI)) }
             return
         }
 

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -152,17 +152,18 @@ open class LogtoClient(
     )
 
     /**
-     * Clear local credentials: drop the cached access tokens and the ID token, and revoke
-     * the refresh token.
+     * Clear local credentials: drop the cached access tokens and the ID token, and attempt
+     * to revoke the refresh token.
      *
-     * Local credentials will be cleared even though there are errors occurred when revoking.
+     * Local credentials are cleared even if the revocation fails or cannot be attempted.
      *
      * Note: this does NOT end the session on the Logto server — the session cookie lives in
      * the browser, which is not accessible to the app, so the next [signIn] may silently
      * re-enter the account through the existing browser session. Use [signOut] for a
      * complete sign-out.
      *
-     * @param[completion] the completion which handles the error occurred when clearing
+     * @param[completion] the completion invoked with any error that occurs while clearing
+     * the credentials
      */
     fun clearCredentials(completion: EmptyCompletion<LogtoException>? = null) {
         if (!isAuthenticated) {
@@ -202,23 +203,27 @@ open class LogtoClient(
      * Local credentials are cleared as soon as the sign-out starts, so the local session
      * always ends even if fetching the OIDC config fails or the browser flow is abandoned.
      *
-     * The refresh token is revoked before the end session endpoint is opened in the
-     * browser. When [postLogoutRedirectUri] is provided, the browser navigates back to
-     * the app through it after the session ends — register the URI in the Logto console
-     * first; its scheme must match the `logtoRedirectScheme` manifest placeholder. When
-     * omitted, the browser shows the Logto sign-out page and the user dismisses it
-     * manually.
+     * The refresh token revocation settles before the end session endpoint is opened in
+     * the browser. When [postLogoutRedirectUri] is provided, the browser navigates back
+     * to the app through it after the session ends — register the URI in the Logto
+     * console first; its scheme must match the `logtoRedirectScheme` manifest
+     * placeholder. When omitted, the browser shows the Logto sign-out page and the user
+     * dismisses it manually.
      *
-     * Dismissing the browser is not reported as an error: the local credentials are
-     * cleared and the refresh token is revoked regardless of how the browser flow ends.
+     * Dismissing the browser is never reported as [LogtoException.Type.USER_CANCELED]:
+     * the local sign-out has already taken effect by the time the browser opens.
+     * Failures of the earlier steps, such as a failed revocation, are still reported
+     * through the [completion].
      *
      * An invalid [postLogoutRedirectUri] is reported as
      * [LogtoException.Type.INVALID_REDIRECT_URI] without opening the browser; local
-     * credentials are still cleared and the refresh token is revoked.
+     * credentials are still cleared and the revocation is still attempted.
      *
      * @param[context] the activity to perform the sign-out action
-     * @param[postLogoutRedirectUri] one of the post sign-out redirect URIs of this application
-     * @param[completion] the completion which handles the error occurred when signing out
+     * @param[postLogoutRedirectUri] one of the post sign-out redirect URIs of this
+     * application, or `null` to let the user dismiss the browser manually after the
+     * session ends
+     * @param[completion] the completion invoked with any error that occurs while signing out
      */
     fun signOut(
         context: Activity,

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -197,18 +197,18 @@ open class LogtoClient(
     }
 
     /**
-     * Sign out: clear local credentials, revoke the refresh token, and end the session
-     * on the Logto server by opening the end session endpoint in the browser.
+     * Sign out: clear local credentials, revoke the refresh token if one is present, and
+     * end the session on the Logto server by opening the end session endpoint in the browser.
      *
      * Local credentials are cleared as soon as the sign-out starts, so the local session
      * always ends even if fetching the OIDC config fails or the browser flow is abandoned.
      *
-     * The refresh token revocation settles before the end session endpoint is opened in
-     * the browser. When [postLogoutRedirectUri] is provided, the browser navigates back
-     * to the app through it after the session ends — register the URI in the Logto
-     * console first; its scheme must match the `logtoRedirectScheme` manifest
-     * placeholder. When omitted, the browser shows the Logto sign-out page and the user
-     * dismisses it manually.
+     * When a refresh token is present its revocation settles before the end session
+     * endpoint is opened in the browser. When [postLogoutRedirectUri] is provided, the
+     * browser navigates back to the app through it after the session ends — register the
+     * URI in the Logto console first; its scheme must match the `logtoRedirectScheme`
+     * manifest placeholder. When omitted, the browser shows the Logto sign-out page and
+     * the user dismisses it manually.
      *
      * Dismissing the browser is never reported as [LogtoException.Type.USER_CANCELED]:
      * the local sign-out has already taken effect by the time the browser opens.

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManager.kt
@@ -30,8 +30,8 @@ internal object LogtoAuthManager {
         browserSession = null
     }
 
-    fun isLogtoAuthResult(uri: Uri) = browserSession?.let { session ->
-        uri.matchesRedirectUri(Uri.parse(session.redirectUri))
+    fun isLogtoAuthResult(uri: Uri) = browserSession?.redirectUri?.let { redirectUri ->
+        uri.matchesRedirectUri(Uri.parse(redirectUri))
     } ?: false
 
     private fun Uri.matchesRedirectUri(redirectUri: Uri): Boolean {

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoBrowserSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoBrowserSession.kt
@@ -4,14 +4,15 @@ import android.net.Uri
 import io.logto.sdk.android.exception.LogtoException
 
 /**
- * A session which performs a round-trip through the system browser
- * and waits for the browser to redirect back to the app.
+ * A session which performs a round-trip through the system browser and completes when
+ * the browser redirects back to the app or the user dismisses the browser; each session
+ * decides how a dismissal is reported.
  */
 interface LogtoBrowserSession {
     /**
      * The URI the browser is expected to redirect back to when this session completes,
-     * or `null` if this session does not expect a redirect and can only be finished by
-     * the user dismissing the browser.
+     * or `null` if this session expects no redirect — the user typically finishes it
+     * by dismissing the browser.
      */
     val redirectUri: String?
 

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoBrowserSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoBrowserSession.kt
@@ -9,9 +9,11 @@ import io.logto.sdk.android.exception.LogtoException
  */
 interface LogtoBrowserSession {
     /**
-     * The URI the browser is expected to redirect back to when this session completes.
+     * The URI the browser is expected to redirect back to when this session completes,
+     * or `null` if this session does not expect a redirect and can only be finished by
+     * the user dismissing the browser.
      */
-    val redirectUri: String
+    val redirectUri: String?
 
     fun handleCallbackUri(callbackUri: Uri)
 

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSession.kt
@@ -26,7 +26,7 @@ class LogtoSignOutSession(
     }
 
     override fun handleUserCancel() {
-        // Local credentials are cleared and the token revocation has settled before
+        // Local credentials are cleared, and any refresh token has been revoked, before
         // the browser opens; ending the server session is best-effort, and without a
         // redirect URI dismissing the browser is the only way back to the app.
         completion.onComplete(null)

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSession.kt
@@ -26,8 +26,8 @@ class LogtoSignOutSession(
     }
 
     override fun handleUserCancel() {
-        // Local credentials are cleared and the refresh token is revoked before the
-        // browser opens; ending the server session is best-effort, and without a
+        // Local credentials are cleared and the token revocation has settled before
+        // the browser opens; ending the server session is best-effort, and without a
         // redirect URI dismissing the browser is the only way back to the app.
         completion.onComplete(null)
     }

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSession.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSession.kt
@@ -11,7 +11,7 @@ import io.logto.sdk.android.exception.LogtoException
 class LogtoSignOutSession(
     private val context: Activity,
     private val signOutUri: String,
-    postLogoutRedirectUri: String,
+    postLogoutRedirectUri: String?,
     private val completion: EmptyCompletion<LogtoException>,
 ) : LogtoBrowserSession {
     override val redirectUri = postLogoutRedirectUri
@@ -26,7 +26,10 @@ class LogtoSignOutSession(
     }
 
     override fun handleUserCancel() {
-        completion.onComplete(LogtoException(LogtoException.Type.USER_CANCELED))
+        // Local credentials are cleared and the refresh token is revoked before the
+        // browser opens; ending the server session is best-effort, and without a
+        // redirect URI dismissing the browser is the only way back to the app.
+        completion.onComplete(null)
     }
 
     override fun handleFailure(exception: LogtoException) {

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
@@ -131,7 +131,7 @@ class LogtoClientTest {
     }
 
     @Test
-    fun `signOut should clear all relative data`() {
+    fun `clearCredentials should clear all relevant data`() {
         every { logtoConfigMock.appId } returns TEST_APP_ID
 
         logtoClient = LogtoClient(logtoConfigMock, mockk())
@@ -149,7 +149,7 @@ class LogtoClientTest {
         mockkObject(Core)
         every { Core.revoke(any(), any(), any(), any()) } just Runs
 
-        logtoClient.signOut(mockk())
+        logtoClient.clearCredentials(mockk())
 
         verify {
             Core.revoke(any(), any(), any(), any())
@@ -159,14 +159,14 @@ class LogtoClientTest {
     }
 
     @Test
-    fun `signOut should complete with exception if not authenticated`() {
+    fun `clearCredentials should complete with exception if not authenticated`() {
         logtoClient = LogtoClient(logtoConfigMock, mockk())
 
         mockkObject(logtoClient)
 
         every { logtoClient.isAuthenticated } returns false
 
-        logtoClient.signOut {
+        logtoClient.clearCredentials {
             assertThat(it)
                 .hasMessageThat()
                 .isEqualTo(LogtoException.Type.NOT_AUTHENTICATED.name)
@@ -174,7 +174,7 @@ class LogtoClientTest {
     }
 
     @Test
-    fun `signOut should complete with exception if get oidc config failed`() {
+    fun `clearCredentials should complete with exception if get oidc config failed`() {
         logtoClient = LogtoClient(logtoConfigMock, mockk())
 
         mockkObject(logtoClient)
@@ -189,7 +189,7 @@ class LogtoClientTest {
             )
         }
 
-        logtoClient.signOut {
+        logtoClient.clearCredentials {
             assertThat(it)
                 .hasMessageThat()
                 .isEqualTo(LogtoException.Type.UNABLE_TO_FETCH_OIDC_CONFIG.name)
@@ -199,7 +199,7 @@ class LogtoClientTest {
     }
 
     @Test
-    fun `signOutWithBrowser should complete with exception if revoke failed`() {
+    fun `clearCredentials should complete with exception if revoke failed`() {
         every { logtoConfigMock.appId } returns TEST_APP_ID
 
         logtoClient = LogtoClient(logtoConfigMock, mockk())
@@ -222,7 +222,7 @@ class LogtoClientTest {
             lastArg<HttpEmptyCompletion>().onComplete(LogtoException(LogtoException.Type.UNABLE_TO_REVOKE_TOKEN))
         }
 
-        logtoClient.signOut {
+        logtoClient.clearCredentials {
             assertThat(it)
                 .hasMessageThat()
                 .isEqualTo(LogtoException.Type.UNABLE_TO_REVOKE_TOKEN.name)
@@ -456,6 +456,89 @@ class LogtoClientTest {
     }
 
     @Test
+    fun `signOut without postLogoutRedirectUri should complete without exception when the browser is dismissed`() {
+        every { logtoConfigMock.appId } returns TEST_APP_ID
+
+        logtoClient = LogtoClient(logtoConfigMock, mockk())
+
+        mockkObject(logtoClient)
+
+        logtoClient.setupRefreshToken(TEST_REFRESH_TOKEN)
+        logtoClient.setupIdToken(TEST_ID_TOKEN)
+
+        every { oidcConfigResponseMock.endSessionEndpoint } returns TEST_END_SESSION_ENDPOINT
+        every { oidcConfigResponseMock.revocationEndpoint } returns TEST_REVOCATION_ENDPOINT
+        every { logtoClient.getOidcConfig(any()) } answers {
+            lastArg<Completion<LogtoException, OidcConfigResponse>>().onComplete(
+                null,
+                oidcConfigResponseMock,
+            )
+        }
+
+        mockkObject(Core)
+        every { Core.revoke(any(), any(), any(), any()) } answers {
+            lastArg<HttpEmptyCompletion>().onComplete(null)
+        }
+
+        val mockActivity: Activity = mockk()
+        every { mockActivity.packageName } returns "logto.test"
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val completionResults = mutableListOf<LogtoException?>()
+        logtoClient.signOut(mockActivity) {
+            completionResults.add(it)
+        }
+
+        // Without a redirect URI, dismissing the browser is the only way back to the app
+        LogtoAuthManager.handleUserCancel()
+
+        assertThat(completionResults).hasSize(1)
+        assertThat(completionResults.last()).isNull()
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun `signOut with postLogoutRedirectUri should complete without exception when the browser is dismissed`() {
+        every { logtoConfigMock.appId } returns TEST_APP_ID
+
+        logtoClient = LogtoClient(logtoConfigMock, mockk())
+
+        mockkObject(logtoClient)
+
+        logtoClient.setupRefreshToken(TEST_REFRESH_TOKEN)
+        logtoClient.setupIdToken(TEST_ID_TOKEN)
+
+        every { oidcConfigResponseMock.endSessionEndpoint } returns TEST_END_SESSION_ENDPOINT
+        every { oidcConfigResponseMock.revocationEndpoint } returns TEST_REVOCATION_ENDPOINT
+        every { logtoClient.getOidcConfig(any()) } answers {
+            lastArg<Completion<LogtoException, OidcConfigResponse>>().onComplete(
+                null,
+                oidcConfigResponseMock,
+            )
+        }
+
+        mockkObject(Core)
+        every { Core.revoke(any(), any(), any(), any()) } answers {
+            lastArg<HttpEmptyCompletion>().onComplete(null)
+        }
+
+        val mockActivity: Activity = mockk()
+        every { mockActivity.packageName } returns "logto.test"
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val completionResults = mutableListOf<LogtoException?>()
+        logtoClient.signOut(mockActivity, "io.logto.android://io.logto.sample/callback") {
+            completionResults.add(it)
+        }
+
+        LogtoAuthManager.handleUserCancel()
+
+        assertThat(completionResults).hasSize(1)
+        assertThat(completionResults.last()).isNull()
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
     fun `signOut with postLogoutRedirectUri should prioritize the browser exception when both flows fail`() {
         every { logtoConfigMock.appId } returns TEST_APP_ID
 
@@ -489,12 +572,12 @@ class LogtoClientTest {
             completionResults.add(it)
         }
 
-        LogtoAuthManager.handleUserCancel()
+        LogtoAuthManager.handleFailure(LogtoException(LogtoException.Type.UNABLE_TO_LAUNCH_BROWSER))
 
         assertThat(completionResults).hasSize(1)
         assertThat(completionResults.last())
             .hasMessageThat()
-            .isEqualTo(LogtoException.Type.USER_CANCELED.name)
+            .isEqualTo(LogtoException.Type.UNABLE_TO_LAUNCH_BROWSER.name)
         assertThat(logtoClient.isAuthenticated).isFalse()
     }
 

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoAuthManagerTest.kt
@@ -92,6 +92,18 @@ class LogtoAuthManagerTest {
     }
 
     @Test
+    fun `isLogtoAuthResult should return false when the session expects no redirect`() {
+        val mockBrowserSession: LogtoBrowserSession = mockk()
+        every { mockBrowserSession.redirectUri } returns null
+
+        LogtoAuthManager.handleAuthStart(mockBrowserSession)
+
+        assertThat(
+            LogtoAuthManager.isLogtoAuthResult(Uri.parse("io.logto.android://io.logto.sample/callback")),
+        ).isFalse()
+    }
+
+    @Test
     fun `isLogtoAuthResult should return false when callback path is only a prefix match`() {
         val redirectUri = "io.logto.android://io.logto.sample/callback"
         val callbackUri = Uri.parse("io.logto.android://io.logto.sample/callback2?state=state&code=code")

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSessionTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/auth/logto/LogtoSignOutSessionTest.kt
@@ -38,10 +38,13 @@ class LogtoSignOutSessionTest {
         LogtoAuthManager.browserSession = null
     }
 
-    private fun createSignOutSession(completion: EmptyCompletion<LogtoException>) = LogtoSignOutSession(
+    private fun createSignOutSession(
+        completion: EmptyCompletion<LogtoException>,
+        postLogoutRedirectUri: String? = dummyPostLogoutRedirectUri,
+    ) = LogtoSignOutSession(
         context = mockActivity,
         signOutUri = dummySignOutUri,
-        postLogoutRedirectUri = dummyPostLogoutRedirectUri,
+        postLogoutRedirectUri = postLogoutRedirectUri,
         completion = completion,
     )
 
@@ -49,6 +52,12 @@ class LogtoSignOutSessionTest {
     fun `redirectUri should be the post logout redirect uri`() {
         val signOutSession = createSignOutSession(mockk())
         assertThat(signOutSession.redirectUri).isEqualTo(dummyPostLogoutRedirectUri)
+    }
+
+    @Test
+    fun `redirectUri should be null when no post logout redirect uri is provided`() {
+        val signOutSession = createSignOutSession(mockk(), postLogoutRedirectUri = null)
+        assertThat(signOutSession.redirectUri).isNull()
     }
 
     @Test
@@ -83,7 +92,7 @@ class LogtoSignOutSessionTest {
     }
 
     @Test
-    fun `handleUserCancel should complete with user canceled exception`() {
+    fun `handleUserCancel should complete without exception`() {
         val logtoExceptionCapture = mutableListOf<LogtoException?>()
         val mockCompletion: EmptyCompletion<LogtoException> = mockk()
         every { mockCompletion.onComplete(any()) } just Runs
@@ -94,9 +103,7 @@ class LogtoSignOutSessionTest {
         verify {
             mockCompletion.onComplete(captureNullable(logtoExceptionCapture))
         }
-        assertThat(logtoExceptionCapture.last())
-            .hasMessageThat()
-            .isEqualTo(LogtoException.Type.USER_CANCELED.name)
+        assertThat(logtoExceptionCapture.last()).isNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Final shape of the v3 sign-out API (follow-up to #250, now merged). The previous overload pair distinguished "local sign-out" from "complete sign-out" only by the presence of a `context` parameter, which is an implementation detail and not inferable from the signature.

- **`signOut(context, postLogoutRedirectUri?, completion?)` is now the only `signOut`** and always performs a complete sign-out: clear local credentials, revoke the refresh token, and end the session on the Logto server via the browser.
- **`postLogoutRedirectUri` is now optional.** When omitted, no console configuration is needed: the browser opens the end session endpoint, Logto shows its default sign-out page, and the user dismisses the tab manually (`Core.generateSignOutUri` already supported this).
- **Dismissing the browser is no longer reported as `USER_CANCELED`.** By the time the browser opens, local credentials are cleared and the refresh token is revoked, so there is nothing left to cancel; the signal is also unreliable (the user may close the tab after the session has already ended) and not actionable by the caller. Without a redirect URI, dismissing the tab is the normal completion path. `USER_CANCELED` remains for sign-in, where cancellation is a genuine failure.
- **The local-only variant is renamed to `clearCredentials(completion?)`** (v2 `signOut(completion)` behavior, unchanged): it cannot touch the browser session cookie, so the next `signIn` may silently SSO back in. The name follows the `clearCredentials` precedent in the Android auth ecosystem and keeps `signOut` unambiguous.
- `LogtoBrowserSession.redirectUri` is nullable accordingly, and `MIGRATION.md` is updated with the rename table and examples.

## Testing

unit tests

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [x] unit tests
- [ ] integration tests (N/A)
- [x] necessary KDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
