### PR TITLE
ci: run commitlint on Node 22 and pin commitlint v21

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,14 +16,17 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
+          # commitlint v21 requires Node >= 22.12; resolve the latest 22.x
+          # instead of trusting a possibly stale runner toolcache.
+          check-latest: true
 
       # Pin the commitlint major version: `npx commitlint` resolves the locally
       # installed CLI instead of pulling the latest release, whose Node

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,11 +23,14 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 22
 
-      - name: Install commitlint config conventional
+      # Pin the commitlint major version: `npx commitlint` resolves the locally
+      # installed CLI instead of pulling the latest release, whose Node
+      # requirement may outgrow the version pinned above.
+      - name: Install commitlint
         run: |
-          npm install @commitlint/config-conventional
+          npm install @commitlint/cli@21 @commitlint/config-conventional@21
 
       - name: Create commitlint config file
         run: |


### PR DESCRIPTION
## Summary

The `lint-commits` job fails on every PR since early June (last green run was on May 8), before it even reads any commit message:

```
Error: yargs parser supports a minimum Node.js version of 20.
```

The workflow pins Node to 16 but installs **unpinned** commitlint via `npx`, which always resolves the latest release. commitlint v21 (and its `yargs-parser` dependency) now requires Node >= 22.12, so the job crashes at startup.

- Bump the job to Node 22.
- Install `@commitlint/cli@21` explicitly and pin both packages to the v21 major, so `npx commitlint` resolves the local install instead of whatever is latest — preventing the same drift from breaking the job again.

## Testing

The `lint-commits` check on this very PR runs the fixed workflow (the `pull_request` event uses the merge-ref workflow file).

## Checklist

- [ ] `.changeset` (N/A)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)