### PR TITLE
docs(android-sdk): document App Links support for the redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,67 @@ android {
 }
 ```
 
+Prefer an `https` redirect URI bound to a domain you own? See
+[Use App Links](#use-app-links-instead-of-a-custom-scheme) below.
+
+### Use App Links instead of a custom scheme
+
+Custom schemes have no ownership: any app can declare the same scheme and race for the
+redirect. [Android App Links](https://developer.android.com/training/app-links) bind an
+`https` redirect URI to a domain you own through a verified
+[Digital Asset Links](https://developers.google.com/digital-asset-links/v1/getting-started)
+file, so the OS guarantees only your app receives the redirect. This is the redirect
+option recommended for native apps by
+[RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252#section-7.2).
+
+The SDK is scheme-agnostic at runtime, and the fully qualified name of the redirect
+receiver activity, `io.logto.sdk.android.auth.logto.LogtoRedirectReceiverActivity`, is
+part of the public API — declare additional intent filters on it in your app's manifest
+and they are merged into the SDK's declaration.
+
+1. Host the Digital Asset Links file at
+   `https://your.domain/.well-known/assetlinks.json`, declaring your application id and
+   the SHA-256 fingerprints of your signing certificates. When publishing with Play App
+   Signing, the release fingerprint comes from Play Console → Setup → App signing. The
+   file must be served as `Content-Type: application/json` with HTTP 200 and no
+   redirects.
+
+2. Declare the App Links intent filter on the SDK's receiver activity in your app's
+   `AndroidManifest.xml`. If you do not use the custom scheme at all, drop the SDK's
+   built-in filter with `tools:node="removeAll"` — the `logtoRedirectScheme` placeholder
+   is then no longer required:
+
+   ```xml
+   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:tools="http://schemas.android.com/tools">
+       <application>
+           <activity android:name="io.logto.sdk.android.auth.logto.LogtoRedirectReceiverActivity">
+               <!-- Omit this line to keep the custom-scheme redirect working alongside. -->
+               <intent-filter tools:node="removeAll" />
+               <intent-filter android:autoVerify="true">
+                   <action android:name="android.intent.action.VIEW" />
+                   <category android:name="android.intent.category.DEFAULT" />
+                   <category android:name="android.intent.category.BROWSABLE" />
+                   <data
+                       android:scheme="https"
+                       android:host="your.domain"
+                       android:path="/callback" />
+               </intent-filter>
+           </activity>
+       </application>
+   </manifest>
+   ```
+
+3. Register `https://your.domain/callback` as a redirect URI (and, if used for
+   sign-out, a post sign-out redirect URI) in the Logto console, and pass it to
+   `signIn` / `signOut`.
+
+Keep in mind that the callback is now a real URL on your domain: serve a fallback page
+there (e.g. a "Return to app" button) for browsers that do not launch App Links on a
+server redirect. On Android 12+ an unverified domain never opens the app, so a broken
+`assetlinks.json` fails silently — check the verification state with
+`adb shell pm get-app-links <applicationId>`.
+
 > Upgrading from v2? See [MIGRATION.md](./MIGRATION.md) for the breaking changes
 > (WebView removal, WeChat/Alipay native sign-in removal, and more).
 

--- a/android-sdk/android/src/main/AndroidManifest.xml
+++ b/android-sdk/android/src/main/AndroidManifest.xml
@@ -36,8 +36,10 @@
 
             Apps may attach additional intent filters to this activity through manifest
             merging (e.g. an App Links filter for an `https` redirect URI), and may drop
-            this built-in filter with `<intent-filter tools:node="removeAll" />` — the
-            placeholder is then no longer required. See "Use App Links" in the README.
+            this built-in filter from their own manifest with
+            `<intent-filter tools:node="removeAll" />` (the app manifest must declare the
+            `tools` namespace) — the placeholder is then no longer required. See
+            "Use App Links" in the README.
         -->
         <activity android:name=".auth.logto.LogtoRedirectReceiverActivity"
             android:exported="true"

--- a/android-sdk/android/src/main/AndroidManifest.xml
+++ b/android-sdk/android/src/main/AndroidManifest.xml
@@ -33,6 +33,11 @@
 
             - the path is fixed to `/callback`, so deep links that share the scheme
               and host but serve other purposes are not routed here.
+
+            Apps may attach additional intent filters to this activity through manifest
+            merging (e.g. an App Links filter for an `https` redirect URI), and may drop
+            this built-in filter with `<intent-filter tools:node="removeAll" />` — the
+            placeholder is then no longer required. See "Use App Links" in the README.
         -->
         <activity android:name=".auth.logto.LogtoRedirectReceiverActivity"
             android:exported="true"

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -206,9 +206,10 @@ open class LogtoClient(
      * When a refresh token is present its revocation settles before the end session
      * endpoint is opened in the browser. When [postLogoutRedirectUri] is provided, the
      * browser navigates back to the app through it after the session ends — register the
-     * URI in the Logto console first; its scheme must match the `logtoRedirectScheme`
-     * manifest placeholder. When omitted, the browser shows the Logto sign-out page and
-     * the user dismisses it manually.
+     * URI in the Logto console first; it must match an intent filter declared for the
+     * app, either the SDK's built-in `logtoRedirectScheme` custom-scheme filter or an
+     * App Links filter the app declares itself. When omitted, the browser shows the
+     * Logto sign-out page and the user dismisses it manually.
      *
      * Dismissing the browser is never reported as [LogtoException.Type.USER_CANCELED]:
      * the local sign-out has already taken effect by the time the browser opens.

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoRedirectReceiverActivity.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoRedirectReceiverActivity.kt
@@ -6,6 +6,10 @@ import android.os.Bundle
 /**
  * Receives the redirect delivered by the browser via the `logtoRedirectScheme` intent filter
  * and forwards it to [LogtoBrowserAuthActivity], clearing the Custom Tab off the back stack.
+ *
+ * The fully qualified name of this activity is public API: integrating apps reference it
+ * from their manifests to attach App Links intent filters (or remove the built-in one)
+ * through manifest merging. Renaming or moving it is a breaking change.
  */
 class LogtoRedirectReceiverActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoRedirectReceiverActivity.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/auth/logto/LogtoRedirectReceiverActivity.kt
@@ -4,8 +4,10 @@ import android.app.Activity
 import android.os.Bundle
 
 /**
- * Receives the redirect delivered by the browser via the `logtoRedirectScheme` intent filter
- * and forwards it to [LogtoBrowserAuthActivity], clearing the Custom Tab off the back stack.
+ * Receives the redirect delivered by the browser via the redirect intent filters declared
+ * for the app — the SDK's built-in `logtoRedirectScheme` filter or an App Links filter the
+ * app declares — and forwards it to [LogtoBrowserAuthActivity], clearing the Custom Tab off
+ * the back stack.
  *
  * The fully qualified name of this activity is public API: integrating apps reference it
  * from their manifests to attach App Links intent filters (or remove the built-in one)


### PR DESCRIPTION
## Summary

Make App Links an officially supported redirect option, ahead of the v3 release. The SDK runtime is already scheme-agnostic (`isValidRedirectUri` and the callback URI matching accept `https` redirect URIs as-is), so this is a documentation/contract change only — no behavior change.

- **README**: new "Use App Links instead of a custom scheme" section covering the full integration path: hosting `assetlinks.json` (including the Play App Signing fingerprint pitfall), declaring the `autoVerify` intent filter on the SDK's receiver activity via manifest merging, console registration, the fallback-page responsibility, and verification via `adb shell pm get-app-links`. Apps that do not use the custom scheme can drop the SDK's built-in filter with `<intent-filter tools:node="removeAll" />`, which also lifts the `logtoRedirectScheme` placeholder requirement (manifest merging processes `tools:node` before placeholder substitution; verified against AGP 7.1.2).
- **Contract**: the fully qualified name of `LogtoRedirectReceiverActivity` is now documented as public API (apps reference it from their manifests), so renaming or moving it becomes a breaking change. Noted in its KDoc and in the SDK manifest comment.
- **KDoc fix**: `signOut` claimed the post sign-out redirect URI's scheme "must match the `logtoRedirectScheme` manifest placeholder", which is not true for App Links; reworded to be scheme-neutral.

## Testing

Tested locally: built the sample app without defining `logtoRedirectScheme` and with an App Links filter declared (both `tools:node="replace"` and `<intent-filter tools:node="removeAll" />` variants) and inspected the merged manifest — the SDK's attributes are inherited, the custom-scheme filter is removed, and the `https` filter with `autoVerify` is in place.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)