### PR TITLE
ci: scope workflows to the v2.x maintenance branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [master]
+    branches: [v2.x]
   pull_request:
-    branches: [master]
+    branches: [v2.x]
 
 jobs:
   main:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [v2.x]
 
 permissions:
   contents: read
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -19,6 +20,20 @@ jobs:
           token: ${{ secrets.BOT_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # GitHub marks the most recently created release as "Latest" by default,
+  # so a maintenance release cut here would steal the badge from the v3 line.
+  unmark-latest:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unmark this release as latest
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: |
+          release_id=$(gh api "repos/${{ github.repository }}/releases/tags/${{ needs.release-please.outputs.tag_name }}" --jq .id)
+          gh api -X PATCH "repos/${{ github.repository }}/releases/$release_id" -f make_latest=false
 
   publish:
     needs: release-please

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "versioning-strategy": "always-bump-patch",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "bump-minor-pre-major": false,


### PR DESCRIPTION
## Summary

`master` is now the v3 line; `v2.x` (cut from the last commit before #249) is the long-term maintenance branch for v2. This PR adapts the workflows on `v2.x` so v2 patches can be released independently — release-please operates per branch: the action's `target-branch` defaults to the branch that triggered the run, and the version is computed from this branch's `.release-please-manifest.json` (currently `2.0.2`).

- **`release.yml` / `main.yml`**: trigger on pushes / PRs to `v2.x` instead of `master`.
- **`release-please-config.json`**: set `versioning-strategy: always-bump-patch` so a stray `feat`/`feat!` commit on the maintenance branch can never bump the version past 2.x.
- **New `unmark-latest` job**: GitHub marks the most recently created release as "Latest" by default, so a v2 patch released after v3.0.0 would steal the badge from the v3 line. The job flips `make_latest=false` on every release cut from this branch (release-please has no built-in option for this — see googleapis/release-please#2317).

`commitlint.yml` and `update-metadata.yml` have no branch filters and already work for PRs targeting `v2.x`; workflows on `master` are untouched.

## Testing

N/A (workflow-only change; will be exercised by the first v2 maintenance release)

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
