### PR TITLE
ci: release v3 as beta prereleases until GA

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "versioning-strategy": "prerelease",
+  "prerelease-type": "beta",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
-  "prerelease": false,
+  "prerelease": true,
   "pull-request-title-pattern": "release: ${version}",
   "pull-request-header": ":robot: Released this version with release-please",
   "packages": {


### PR DESCRIPTION
## Summary

Switch master releases to beta prereleases while v3 stabilizes (passkey acceptance and App Links are still open):

- `versioning-strategy: prerelease` + `prerelease-type: beta`: with the breaking commits already on master, the pending release PR (#245) will turn into `release: 3.0.0-beta` on its next refresh; every subsequent release bumps the prerelease number (`3.0.0-beta.1`, `3.0.0-beta.2`, …) regardless of commit type, so further breaking changes during the beta phase cannot bump the major again.
- `prerelease: true`: required by the prerelease versioning strategy, and marks beta releases as **Pre-release** on GitHub — they never take the "Latest" badge, so they don't interfere with the v2 line.

The `publish` job is unaffected: betas are published to Maven Central as usual.

To graduate to GA, revert this config and force the final version with an empty commit carrying a `Release-As: 3.0.0` footer.

## Testing

N/A (release config only; will be exercised by the next release PR refresh)

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
