### PR TITLE
ci: pin release-please target branch to v2.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
           token: ${{ secrets.BOT_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Without this, release-please falls back to the repository default
+          # branch (master) and never builds a release PR for this branch.
+          target-branch: v2.x
 
   # GitHub marks the most recently created release as "Latest" by default,
   # so a maintenance release cut here would steal the badge from the v3 line.


### PR DESCRIPTION
## Summary

Follow-up to #256. The first Release run on `v2.x` (after #256 merged) shows release-please targeting `master` instead of `v2.x`:

```
❯ Fetching release-please-config.json from branch master
❯ targetBranch: master
✔ PR https://github.com/logto-io/kotlin/pull/245 remained the same
```

The action's `target-branch` input does **not** default to the triggering branch — it falls back to the repository default branch. So pushes to `v2.x` were re-evaluating the v3 release PR on master and never building one for the v2 line.

This pins `target-branch: v2.x` so release-please reads the config/manifest from `v2.x` and opens release PRs against it. Once merged, the very next run should open `release: 2.0.3` (the branch already carries the unreleased fixes #244 and #247).

## Testing

N/A (verified against the run log above; will be exercised by the merge push of this PR)

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
