### PR TITLE
fix(android-sdk): add -dontwarn consumer rules for optional social SDKs

### DIFF
--- a/android-sdk/android/proguard-rules.pro
+++ b/android-sdk/android/proguard-rules.pro
@@ -1,1 +1,6 @@
 -keep class io.logto.sdk.core.type.** { *; }
+
+# The Alipay and WeChat SDKs are compileOnly dependencies; apps that don't
+# bundle them must not fail R8 full-mode missing-class checks.
+-dontwarn com.alipay.sdk.**
+-dontwarn com.tencent.mm.opensdk.**


### PR DESCRIPTION
## Summary

Fixes #255.

The v2 SDK ships built-in Alipay/WeChat social sessions whose SDKs are `compileOnly` dependencies. Apps that don't bundle those SDKs fail release builds under R8 full mode (the default since AGP 8) with hard missing-class errors:

```
Missing class com.alipay.sdk.app.OpenAuthTask (referenced from: ...AlipaySocialSession...)
Missing class com.tencent.mm.opensdk.openapi.IWXAPI (referenced from: ...WechatSocialSession...)
```

This adds `-dontwarn com.alipay.sdk.**` and `-dontwarn com.tencent.mm.opensdk.**` to the consumer ProGuard rules shipped with the AAR (via the existing `consumerProguardFile`), so consuming apps no longer need to maintain the `-dontwarn` workaround themselves. The two patterns cover everything the SDK references from the optional dependencies (`com.alipay.sdk.app.OpenAuthTask` and the `com.tencent.mm.opensdk.{constants,modelbase,modelmsg,openapi}` classes).

v3 (`master`) is unaffected — the built-in social connectors were removed there in #249.

## Testing

N/A — consumer ProGuard rules only; the referenced class patterns were verified against the SDK's imports.

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)