### PR TITLE
ci: fix release-please versioning config key

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "versioning-strategy": "prerelease",
+  "versioning": "prerelease",
   "prerelease-type": "beta",
   "include-v-in-tag": true,
   "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

Follow-up to #257, which had no effect: the manifest config key for the versioning strategy is `versioning`, not `versioning-strategy` (see [`manifest.ts`](https://github.com/googleapis/release-please/blob/main/src/manifest.ts) — `versioning: config['versioning']`; unknown keys are silently ignored). That's why the post-merge run logged `PR #245 remained the same` instead of refreshing it to `3.0.0-beta`.

With the correct key, the merge push of this PR will trigger release-please to recompute and retitle #245 to `release: 3.0.0-beta`.

## Testing

N/A (verified against release-please source and the run log; will be exercised by the merge push of this PR)

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
