### PR TITLE
ci: fix release-please versioning config key

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "versioning-strategy": "always-bump-patch",
+  "versioning": "always-bump-patch",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "bump-minor-pre-major": false,


### PR DESCRIPTION
## Summary

Same fix as #261 for the v2 line: the manifest config key is `versioning`, not `versioning-strategy` (unknown keys are silently ignored by release-please), so the `always-bump-patch` guard from #256 was not actually in effect.

## Testing

N/A (verified against release-please source)

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
