### PR TITLE
fix(android-sdk): invalidate unauthenticated sign-out and keep omitted refresh tokens

### DIFF
--- a/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
+++ b/android-sdk/android/src/main/kotlin/io/logto/sdk/android/LogtoClient.kt
@@ -186,6 +186,7 @@ open class LogtoClient(
      */
     fun clearCredentials(completion: EmptyCompletion<LogtoException>? = null) {
         if (!isAuthenticated) {
+            credentialGuard.invalidate()
             completion?.onComplete(LogtoException(LogtoException.Type.NOT_AUTHENTICATED))
             return
         }
@@ -251,6 +252,7 @@ open class LogtoClient(
         completion: EmptyCompletion<LogtoException>? = null,
     ) {
         if (!isAuthenticated) {
+            credentialGuard.invalidate()
             completion?.onComplete(LogtoException(LogtoException.Type.NOT_AUTHENTICATED))
             return
         }
@@ -424,7 +426,9 @@ open class LogtoClient(
                     credentialStamp = credentialStamp,
                     issuer = oidcConfig.issuer,
                     responseIdToken = refreshedToken.idToken,
-                    responseRefreshToken = refreshedToken.refreshToken,
+                    // RFC 6749 §6: keep the current refresh token when the response
+                    // does not issue a new one
+                    responseRefreshToken = refreshedToken.refreshToken ?: tokenForRefresh,
                     accessTokenKey = buildAccessTokenKey(null, resource, organizationId),
                     accessToken = refreshedAccessToken,
                 ) { verifyException ->
@@ -681,6 +685,11 @@ private class CredentialGuard {
 
     @Synchronized
     fun isCurrent(stamp: Int): Boolean = stamp == version
+
+    @Synchronized
+    fun invalidate() {
+        version++
+    }
 
     @Synchronized
     fun <T> invalidate(block: () -> T): T {

--- a/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
+++ b/android-sdk/android/src/test/kotlin/io/logto/sdk/android/LogtoClientTest.kt
@@ -813,6 +813,125 @@ class LogtoClientTest {
     }
 
     @Test
+    fun `signOut during an unauthenticated ongoing sign-in should discard the sign-in result`() {
+        setupDeferredRefreshTestEnv()
+        logtoClient.setupIdToken(null)
+        logtoClient.setupRefreshToken(null)
+
+        every { oidcConfigResponseMock.authorizationEndpoint } returns "https://logto.dev/oidc/auth"
+        every { logtoConfigMock.scopes } returns emptyList()
+        every { logtoConfigMock.resources } returns null
+        every { logtoConfigMock.prompt } returns "consent"
+        every { logtoConfigMock.includeReservedScopes } returns true
+
+        val codeExchangeCompletions = mutableListOf<HttpCompletion<CodeTokenResponse>>()
+        every {
+            Core.fetchTokenByAuthorizationCode(any(), any(), any(), any(), any(), any(), any())
+        } answers {
+            codeExchangeCompletions.add(lastArg())
+        }
+
+        mockkObject(CallbackUriUtils)
+        every {
+            CallbackUriUtils.verifyAndParseCodeFromCallbackUri(any(), any(), any())
+        } returns "testAuthCode"
+
+        val mockActivity: Activity = mockk()
+        every { mockActivity.packageName } returns "logto.test"
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val signInResults = mutableListOf<LogtoException?>()
+        logtoClient.signIn(mockActivity, "io.logto.android://io.logto.sample/callback") {
+            signInResults.add(it)
+        }
+
+        LogtoAuthManager.handleCallbackUri(
+            Uri.parse("io.logto.android://io.logto.sample/callback?code=testAuthCode"),
+        )
+        assertThat(codeExchangeCompletions).hasSize(1)
+
+        logtoClient.signOut(mockActivity, "io.logto.android://io.logto.sample/callback")
+
+        codeExchangeCompletions.last().onComplete(null, mockCodeTokenResponse())
+
+        assertThat(signInResults).hasSize(1)
+        assertThat(signInResults.last())
+            .hasMessageThat()
+            .contains(LogtoException.Type.NOT_AUTHENTICATED.name)
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun `clearCredentials during an unauthenticated ongoing sign-in should discard the sign-in result`() {
+        setupDeferredRefreshTestEnv()
+        logtoClient.setupIdToken(null)
+        logtoClient.setupRefreshToken(null)
+
+        every { oidcConfigResponseMock.authorizationEndpoint } returns "https://logto.dev/oidc/auth"
+        every { logtoConfigMock.scopes } returns emptyList()
+        every { logtoConfigMock.resources } returns null
+        every { logtoConfigMock.prompt } returns "consent"
+        every { logtoConfigMock.includeReservedScopes } returns true
+
+        val codeExchangeCompletions = mutableListOf<HttpCompletion<CodeTokenResponse>>()
+        every {
+            Core.fetchTokenByAuthorizationCode(any(), any(), any(), any(), any(), any(), any())
+        } answers {
+            codeExchangeCompletions.add(lastArg())
+        }
+
+        mockkObject(CallbackUriUtils)
+        every {
+            CallbackUriUtils.verifyAndParseCodeFromCallbackUri(any(), any(), any())
+        } returns "testAuthCode"
+
+        val mockActivity: Activity = mockk()
+        every { mockActivity.packageName } returns "logto.test"
+        every { mockActivity.startActivity(any()) } just Runs
+
+        val signInResults = mutableListOf<LogtoException?>()
+        logtoClient.signIn(mockActivity, "io.logto.android://io.logto.sample/callback") {
+            signInResults.add(it)
+        }
+
+        LogtoAuthManager.handleCallbackUri(
+            Uri.parse("io.logto.android://io.logto.sample/callback?code=testAuthCode"),
+        )
+        assertThat(codeExchangeCompletions).hasSize(1)
+
+        logtoClient.clearCredentials()
+
+        codeExchangeCompletions.last().onComplete(null, mockCodeTokenResponse())
+
+        assertThat(signInResults).hasSize(1)
+        assertThat(signInResults.last())
+            .hasMessageThat()
+            .contains(LogtoException.Type.NOT_AUTHENTICATED.name)
+        assertThat(logtoClient.isAuthenticated).isFalse()
+    }
+
+    @Test
+    fun `a refresh response without a refresh token should keep the existing one`() {
+        setupDeferredRefreshTestEnv()
+        every { logtoConfigMock.resources } returns listOf(TEST_RESOURCE_1)
+
+        // The first refresh succeeds, but its response does not issue a new refresh token
+        val accessTokenResults = mutableListOf<AccessToken?>()
+        logtoClient.getAccessToken { _, result -> accessTokenResults.add(result) }
+        assertThat(pendingRefreshCompletions).hasSize(1)
+        pendingRefreshCompletions.last().onComplete(
+            null,
+            mockRefreshTokenTokenResponse(refreshToken = null),
+        )
+        assertThat(requireNotNull(accessTokenResults.last()).token).isEqualTo(TEST_ACCESS_TOKEN)
+
+        // A refresh for another resource must still run, on the kept refresh token
+        logtoClient.getAccessToken(TEST_RESOURCE_1) { _, _ -> }
+        assertThat(pendingRefreshCompletions).hasSize(2)
+        assertThat(usedRefreshTokens.last()).isEqualTo(TEST_REFRESH_TOKEN)
+    }
+
+    @Test
     fun `getAccessToken should fail without being authenticated`() {
         logtoClient = LogtoClient(logtoConfigMock, mockk())
 
@@ -1305,7 +1424,7 @@ class LogtoClientTest {
 
     private fun mockRefreshTokenTokenResponse(
         accessToken: String = TEST_ACCESS_TOKEN,
-        refreshToken: String = TEST_REFRESH_TOKEN,
+        refreshToken: String? = TEST_REFRESH_TOKEN,
     ): RefreshTokenTokenResponse {
         val response: RefreshTokenTokenResponse = mockk()
         every { response.accessToken } returns accessToken


### PR DESCRIPTION
## Summary

Mirrors to master the two credential-guard hardenings that landed on the v2.x backport PR #264, so the branches stay in lockstep:

- **Invalidate unauthenticated sign-out flows** (ports `abbd42b` from #264): `signOut` / `clearCredentials` called while not authenticated used to early-return without bumping the credential generation, so a sign-in whose code exchange was still in flight would complete and sign the user in *after* they had expressed sign-out intent. Both early returns now invalidate pending flows first (new no-arg `CredentialGuard.invalidate()` overload).
- **Keep the refresh token when a refresh response omits it** (the Copilot finding on #264): the refresh path now falls back to the token the request was made with (`refreshedToken.refreshToken ?: tokenForRefresh`), per RFC 6749 §6. The code-exchange path is intentionally unchanged — a sign-in response without a refresh token still clears any previous one. Unreachable against Logto's own OP (which always returns a refresh token on the refresh grant), but correct per spec and keeps the token-persistence code identical across branches.

## Testing

unit tests — three new: sign-out-during-unauthenticated-sign-in (both `signOut` and `clearCredentials` entry points) and refresh-response-without-refresh-token. Red-check verified: exactly these 3 fail on current master, all 45 pass with the fix.

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please)
- [x] unit tests
- [ ] integration tests (N/A)
- [x] necessary KDoc comments (N/A — no public API changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)