### PR TITLE
docs: explain the v3/v2 version split and consolidate the sign-out migration sample

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -74,36 +74,44 @@ on Maven Central and receives fixes on the `v2.x` line.
 
 ## Changed: sign-out API
 
-In v3, `signOut` performs a complete sign-out: it clears local credentials, revokes the
-refresh token (when one is present), and ends the session on the Logto server by opening
-the end session endpoint in the browser. Local credentials are always cleared; the remote
-steps are best-effort and need the OIDC config to be reachable — any failure is reported
-through the completion.
+The v2 `signOut(completion)` is renamed to `clearCredentials(completion)` with unchanged
+behavior, and v3 adds the browser-based `signOut(context, postLogoutRedirectUri?, completion?)`
+for a complete sign-out: it clears local credentials, revokes the refresh token (when one
+is present), and ends the session on the Logto server by opening the end session endpoint
+in the browser. Local credentials are always cleared; the remote steps are best-effort
+and need the OIDC config to be reachable — any failure is reported through the completion.
+
+This leaves three ways to sign out — the [Kotlin sample app](./android-sample-kotlin)
+demonstrates them side by side:
 
 ```kotlin
-// The browser opens briefly and navigates back to the app through the post sign-out
-// redirect URI (register it in the Logto console first; its scheme must also match
-// `logtoRedirectScheme`):
+// 1. Complete sign-out: ends the Logto session in the browser, which then navigates
+//    back to the app through the post sign-out redirect URI (register it in the Logto
+//    console first; its scheme must also match `logtoRedirectScheme`):
 logtoClient.signOut(this, "io.logto.android://io.logto.sample/callback") { exception ->
     // ...
 }
 
-// Or omit the URI — no console configuration needed; the browser shows the Logto
-// sign-out page and the user dismisses it manually:
+// 2. Complete sign-out, no redirect back: same effect on the Logto session, no console
+//    configuration needed — the browser shows the Logto sign-out page and the user
+//    returns by dismissing it manually:
 logtoClient.signOut(this)
+
+// 3. Local sign-out — this is v2's `signOut(completion)`, renamed: clears local
+//    credentials and revokes the refresh token, but keeps the Logto session, because
+//    the session cookie now lives in the browser, which the app cannot touch. The next
+//    `signIn` may silently re-enter the account through that session. Use it when no
+//    UI context is available (e.g. forcing a local sign-out from a background error
+//    handler); otherwise prefer `signOut`:
+logtoClient.clearCredentials { exception ->
+    // ...
+}
 ```
 
 Dismissing the browser during sign-out is never reported as `USER_CANCELED`: local
 credentials are cleared and the token revocation has settled before the browser opens,
 so the sign-out has already taken effect. Failures of the earlier steps (such as a
 failed revocation) are still reported through the completion.
-
-The v2 `signOut(completion)` is renamed to `clearCredentials(completion)` with unchanged
-behavior: it clears local credentials and revokes the refresh token, but it cannot clear
-the session cookie — that cookie now lives in the browser, which the app cannot touch.
-After clearing credentials, the next `signIn` may silently re-enter the account through
-the existing browser session. Prefer `signOut`; use `clearCredentials` when no UI context
-is available (e.g. forcing a local sign-out from a background error handler).
 
 ## Other breaking changes
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,28 @@ The monorepo for SDKs written in Kotlin.
 
 Check out the [Android SDK tutorial](https://docs.logto.io/sdk/android) for more information.
 
+## Versions
+
+| Version | Branch | Status |
+|---|---|---|
+| v3 (beta) | [`master`](https://github.com/logto-io/kotlin/tree/master) | In development — released as `3.0.0-beta` prereleases until GA |
+| v2 (stable) | [`v2.x`](https://github.com/logto-io/kotlin/tree/v2.x) | Maintenance — bug fixes only |
+
+v3 moves the sign-in experience from an embedded WebView to
+[Chrome Custom Tabs](https://developer.android.com/develop/ui/views/layout/webapps/overview-of-android-custom-tabs)
+(the system browser) — unlocking WebAuthn/passkeys and sharing the browser session —
+and revamps the sign-out API accordingly. WeChat / Alipay **native** sign-in is removed
+(social connectors keep working, through the browser); if you depend on the native
+social SDKs, stay on v2.
+
+- **Upgrading from v2?** Follow [MIGRATION.md](./MIGRATION.md).
+- This README documents v3. The v2 documentation lives in the
+  [`v2.x` README](https://github.com/logto-io/kotlin/blob/v2.x/README.md).
+
 ## Installation
 Logto Android SDK is now available on [MavenCentral](https://search.maven.org/search?q=io.logto.sdk).
+v3 is in beta: use the latest `3.0.0-beta` prerelease as the version below. For the
+stable v2 line, see [Versions](#versions).
 
 ### Groovy
 ```groovy


### PR DESCRIPTION
## Summary

The default branch documents v3, but nothing on it tells readers which major version they are looking at, where v2 lives, or how to move between them. This adds a **Versions** section at the top of the README:

- a small table mapping v3 (beta, `master`, released as `3.0.0-beta` prereleases until GA) and v2 (stable, [`v2.x`](https://github.com/logto-io/kotlin/tree/v2.x), bug fixes only) to their branches;
- a three-line summary of what v3 changes (Custom Tabs instead of WebView → passkeys + browser SSO, revamped sign-out, WeChat/Alipay native sign-in removed — stay on v2 if you need it);
- a prominent entry point to [MIGRATION.md](./MIGRATION.md) (previously only linked from deep inside the App Links section) and a pointer to the v2 README for v2 docs;
- a note in **Installation** that v3 versions are `3.0.0-beta` prereleases.

Also reworks the **sign-out section of MIGRATION.md**: `clearCredentials` was explained in a trailing paragraph detached from the code sample; the section now opens with the v2 → v3 rename and shows all three sign-out flavors in one code block (complete with redirect / complete without redirect / local only), mirroring the three buttons in the Kotlin sample app, with the cookie-stays-in-the-browser caveat as the comment on the `clearCredentials` variant.

Note: the wording assumes the first `3.0.0-beta` prerelease is published — best merged after release PR #245 has shipped.

## Testing

Markdown only; previewed the rendered table and anchors (`#versions` link target).

## Checklist

- [ ] `.changeset` (N/A — this repo uses release-please; `docs:` does not bump the version)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
