### PR TITLE
ci: sign the release PR commit with the bot GPG key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,39 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # release-please creates its commits through the REST API, which cannot produce
+      # GPG signatures, but the branch ruleset requires verified signatures on every
+      # PR commit. Re-sign the release PR commit with the bot's key (same key and
+      # setup as logto-io/js).
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.BOT_PAT }}
+
+      - name: Import bot GPG key
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.BOT_GPG_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Sign the release PR commit
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        run: |
+          # Only amend truly unsigned commits ("N"); a manually re-signed commit
+          # ("E"/"U"/"G") is left alone so checks are not re-triggered for nothing.
+          if [ "$(git log -1 --format=%G?)" != "N" ]; then
+            echo "Release PR head commit is already signed, nothing to do"
+            exit 0
+          fi
+          git config user.name silverhand-bot
+          git config user.email bot@silverhand.io
+          git commit --amend --no-edit --gpg-sign
+          git push --force
+
   publish:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,11 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
    | `feat!:` or commit body containing `BREAKING CHANGE:` | major (**X+1**.0.0) |
    | `chore:` / `refactor:` / `docs:` / `test:` / `ci:` / `revert:` | no bump (still listed in changelog) |
 
+   release-please creates the release PR commit through the REST API, which cannot
+   produce a GPG signature, so the workflow immediately amends the commit with the
+   bot's GPG key (`BOT_GPG_KEY` org secret, shared with logto-io/js) — without this
+   the branch ruleset's required-signatures rule blocks the merge.
+
 3. Merging the release PR triggers the workflow again. release-please creates the git tag `vX.Y.Z` and a GitHub Release with auto-generated notes immediately, then sets `releases_created=true`.
 4. The publish job (gated on `releases_created`) runs next:
    - Builds and signs `io.logto.sdk:kotlin` and `io.logto.sdk:android` with in-memory PGP keys.


### PR DESCRIPTION
## Summary

The branch ruleset requires verified signatures on every PR commit, but release-please creates its release PR commits through the REST API, which cannot produce GPG signatures — so release PRs (first hit: #245) are unmergeable. There is nothing to configure on the bot account for this: only git-CLI commits can be signed, and release-please has no signing support upstream.

logto-io/js does not have this problem because changesets/action commits via the git CLI with silverhand-bot's GPG key imported (`crazy-max/ghaction-import-gpg` + `BOT_GPG_KEY` / `BOT_GPG_PASSPHRASE` org secrets, both already visible to this repo).

This PR ports that setup: after release-please runs, when a release PR was created or updated (`prs_created`), the workflow checks out the release branch, imports the bot key, and `git commit --amend --no-edit --gpg-sign` + force-pushes — the commit keeps its author and message and becomes Verified. A guard skips amending when the head commit is already signed (e.g. re-signed by hand, like #245 just was), so checks are not re-triggered for nothing. Pushes use `BOT_PAT` so the PR's required status checks still trigger on the new SHA.

Also documents the step in RELEASE.md.

Note: the `v2.x` release workflow needs the same treatment before `release: 2.0.3` (#260) can merge — mirror PR to follow.

## Testing

- Verified `BOT_GPG_KEY` / `BOT_GPG_PASSPHRASE` are org secrets visible to this repo.
- The mechanism (amend + re-sign + force-push, author preserved) is exactly what unblocked #245 manually today; this automates it with the bot's key.
- The js publish workflow has been producing Verified silverhand-bot commits with the same key/action for a long time.

## Checklist

- [ ] `.changeset` (N/A — release-please)
- [ ] unit tests (N/A — workflow change)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)