### PR TITLE
ci: re-sign the release branch on every push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,16 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - 'release-please--branches--**'
 
 permissions:
   contents: read
 
 jobs:
   release-please:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
@@ -20,18 +23,21 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # release-please creates its commits through the REST API, which cannot produce
-      # GPG signatures, but the branch ruleset requires verified signatures on every
-      # PR commit. Re-sign the release PR commit with the bot's key (same key and
-      # setup as logto-io/js).
+  # The branch ruleset requires verified signatures on every PR commit, but two
+  # paths put unsigned commits on the release branch: release-please creates its
+  # commits through the REST API (which cannot sign), and the "Update branch"
+  # rebase button rewrites the commit unsigned. Reacting to pushes on the release
+  # branch itself covers both: whenever its head commit is unsigned, amend it with
+  # the bot's GPG key (same key and setup as logto-io/js).
+  sign-release-branch:
+    if: startsWith(github.ref_name, 'release-please--branches--')
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
         with:
-          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           token: ${{ secrets.BOT_PAT }}
 
       - name: Import bot GPG key
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.BOT_GPG_KEY }}
@@ -39,19 +45,18 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Sign the release PR commit
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+      - name: Sign the head commit when unsigned
         run: |
-          # Only amend truly unsigned commits ("N"); a manually re-signed commit
-          # ("E"/"U"/"G") is left alone so checks are not re-triggered for nothing.
+          # Only amend truly unsigned commits ("N"); an already-signed commit
+          # ("E"/"U"/"G") is left alone so this job does not retrigger itself.
           if [ "$(git log -1 --format=%G?)" != "N" ]; then
-            echo "Release PR head commit is already signed, nothing to do"
+            echo "Head commit is already signed, nothing to do"
             exit 0
           fi
           git config user.name silverhand-bot
           git config user.email bot@silverhand.io
           git commit --amend --no-edit --gpg-sign
-          git push --force
+          git push --force origin HEAD:${{ github.ref_name }}
 
   publish:
     needs: release-please

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,9 +15,11 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
    | `chore:` / `refactor:` / `docs:` / `test:` / `ci:` / `revert:` | no bump (still listed in changelog) |
 
    release-please creates the release PR commit through the REST API, which cannot
-   produce a GPG signature, so the workflow immediately amends the commit with the
-   bot's GPG key (`BOT_GPG_KEY` org secret, shared with logto-io/js) — without this
-   the branch ruleset's required-signatures rule blocks the merge.
+   produce a GPG signature, and the "Update branch" rebase button also rewrites the
+   commit unsigned — either way the branch ruleset's required-signatures rule would
+   block the merge. Every push to the release branch therefore runs a job that
+   amends an unsigned head commit with the bot's GPG key (`BOT_GPG_KEY` org secret,
+   shared with logto-io/js).
 
 3. Merging the release PR triggers the workflow again. release-please creates the git tag `vX.Y.Z` and a GitHub Release with auto-generated notes immediately, then sets `releases_created=true`.
 4. The publish job (gated on `releases_created`) runs next:


### PR DESCRIPTION
## Summary

#267 hooked the signing steps into the release-please job, gated on `prs_created` — i.e. they only ran when release-please itself created or updated the release PR **in that same run**. Real life immediately found the two gaps:

1. an unsigned commit left by an **earlier** run is never revisited (later runs see "content unchanged", skip, and the branch stays unmergeable);
2. the **Update branch (rebase)** button rewrites the release commit server-side and drops the signature — no master push follows, so the old hook never fires at all (this is exactly what produced the unsigned `062b0fd` on #245 today).

This PR moves the signing out of the release-please job into a `sign-release-branch` job triggered by **pushes to `release-please--branches--**`** — it reacts to the branch state, not to who changed it. Whether the unsigned head comes from release-please's REST-API force-push, a manual rebase update, or anything else: push event → if head commit is unsigned (`%G?` = N), amend with the bot's GPG key and force-push. Already-signed heads are left alone, which also guarantees the job cannot retrigger itself.

Also: the `release-please` job is now explicitly gated to master pushes, the push uses an explicit refspec (`HEAD:ref_name`, the previous bare `git push --force` had no upstream on a detached checkout), and RELEASE.md is updated.

Note: a workflow only fires for branches whose tree contains it, so the first rebase-update of #245 after this merges will pull the new release.yml into the release branch and the job will sign the rebased commit — that rebase is the live acceptance test.

The v2.x release workflow still needs the same treatment (mirror PR planned together with the rest of the signing setup, before `release: 2.0.3` #260).

## Testing

- Acceptance: after merging, press **Update branch (rebase)** on #245 — the rebased commit starts unsigned, the push triggers `sign-release-branch`, and the head flips to Verified within ~1 minute.
- The amend+sign mechanics are the same ones used to unblock #245 by hand three times today (author/message preserved, GitHub reports `verified: true`).

## Checklist

- [ ] `.changeset` (N/A — release-please)
- [ ] unit tests (N/A — workflow change)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)