### PR TITLE
ci: fetch full history before amending the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PAT }}
+          # Amending in the default shallow clone rewrites the head commit into a
+          # parentless orphan (its parents are behind the shallow boundary) — the
+          # full history is required for the amend to keep the parent.
+          fetch-depth: 0
 
       - name: Import bot GPG key
         uses: crazy-max/ghaction-import-gpg@v6
@@ -56,6 +60,13 @@ jobs:
           git config user.name silverhand-bot
           git config user.email bot@silverhand.io
           git commit --amend --no-edit --gpg-sign
+          # Never push a history rewrite: the amended commit must keep its parent
+          # (an empty %P means the orphan bug above — abort instead of clobbering
+          # the branch and auto-closing the release PR).
+          if [ -z "$(git log -1 --format=%P)" ]; then
+            echo "Amended commit lost its parent; refusing to push" >&2
+            exit 1
+          fi
           git push --force origin HEAD:${{ github.ref_name }}
 
   publish:


### PR DESCRIPTION
## Summary

Fixes the bug that just destroyed release PR #245. The `sign-release-branch` job from #268 used the default **shallow checkout** (`fetch-depth: 1`): `git commit --amend` in a clone whose parent objects are behind the shallow boundary rewrote the release commit into a **parentless orphan** containing the whole repo tree (181 files, hence the size/xl relabel). Force-pushing that orphan left the release branch with no common ancestor with master, so GitHub auto-closed #245 as unmergeable — attributed to silverhand-bot, whose PAT pushed it.

Two changes:

- `fetch-depth: 0` on the checkout, so the amend keeps the commit's parent;
- a post-amend guard: if the amended commit has an empty `%P`, abort instead of pushing — a history rewrite must never reach the branch again, whatever the cause.

## Recovery

No manual branch surgery needed — merging this PR is the recovery: the master push makes release-please notice its PR is closed, force-push a fresh, correctly-parented release commit over the orphan, and open a new `release: 3.0.0-beta` PR; that push then triggers the fixed sign job, which amends it with the bot's GPG key. The new release PR should come up green and Verified, ready to merge.

## Testing

- Reproduced the failure mode from the evidence: `c693c58` has `parents: []` and the full tree as its diff, exactly what a shallow amend produces.
- The guard condition (`git log -1 --format=%P` empty on orphan, non-empty otherwise) is the direct negation of the corruption.

## Checklist

- [ ] `.changeset` (N/A — release-please)
- [ ] unit tests (N/A — workflow change)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)