### PR TITLE
ci: sign the release branch with the bot GPG key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,16 @@ name: Release
 
 on:
   push:
-    branches: [v2.x]
+    branches:
+      - v2.x
+      - 'release-please--branches--**'
 
 permissions:
   contents: read
 
 jobs:
   release-please:
+    if: github.ref == 'refs/heads/v2.x'
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
@@ -23,6 +26,52 @@ jobs:
           # Without this, release-please falls back to the repository default
           # branch (master) and never builds a release PR for this branch.
           target-branch: v2.x
+
+  # The branch ruleset requires verified signatures on every PR commit, but two
+  # paths put unsigned commits on the release branch: release-please creates its
+  # commits through the REST API (which cannot sign), and the "Update branch"
+  # rebase button rewrites the commit unsigned. Reacting to pushes on the release
+  # branch itself covers both: whenever its head commit is unsigned, amend it with
+  # the bot's GPG key (same key and setup as logto-io/js).
+  sign-release-branch:
+    if: startsWith(github.ref_name, 'release-please--branches--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          # Amending in the default shallow clone rewrites the head commit into a
+          # parentless orphan (its parents are behind the shallow boundary) — the
+          # full history is required for the amend to keep the parent.
+          fetch-depth: 0
+
+      - name: Import bot GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.BOT_GPG_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Sign the head commit when unsigned
+        run: |
+          # Only amend truly unsigned commits ("N"); an already-signed commit
+          # ("E"/"U"/"G") is left alone so this job does not retrigger itself.
+          if [ "$(git log -1 --format=%G?)" != "N" ]; then
+            echo "Head commit is already signed, nothing to do"
+            exit 0
+          fi
+          git config user.name silverhand-bot
+          git config user.email bot@silverhand.io
+          git commit --amend --no-edit --gpg-sign
+          # Never push a history rewrite: the amended commit must keep its parent
+          # (an empty %P means the orphan bug above — abort instead of clobbering
+          # the branch and auto-closing the release PR).
+          if [ -z "$(git log -1 --format=%P)" ]; then
+            echo "Amended commit lost its parent; refusing to push" >&2
+            exit 1
+          fi
+          git push --force origin HEAD:${{ github.ref_name }}
 
   # GitHub marks the most recently created release as "Latest" by default,
   # so a maintenance release cut here would steal the badge from the v3 line.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,13 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
    | `feat!:` or commit body containing `BREAKING CHANGE:` | major (**X+1**.0.0) |
    | `chore:` / `refactor:` / `docs:` / `test:` / `ci:` / `revert:` | no bump (still listed in changelog) |
 
+   release-please creates the release PR commit through the REST API, which cannot
+   produce a GPG signature, and the "Update branch" rebase button also rewrites the
+   commit unsigned — either way the branch ruleset's required-signatures rule would
+   block the merge. Every push to the release branch therefore runs a job that
+   amends an unsigned head commit with the bot's GPG key (`BOT_GPG_KEY` org secret,
+   shared with logto-io/js).
+
 3. Merging the release PR triggers the workflow again. release-please creates the git tag `vX.Y.Z` and a GitHub Release with auto-generated notes immediately, then sets `releases_created=true`.
 4. The publish job (gated on `releases_created`) runs next:
    - Builds and signs `io.logto.sdk:kotlin` and `io.logto.sdk:android` with in-memory PGP keys.


### PR DESCRIPTION
## Summary

Mirrors the release-branch signing setup to the `v2.x` line, in its final form after the three rounds it took on master (#267 → #268 → #269): without it, `release: 2.0.3` (#260) is unmergeable against the required-signatures ruleset, exactly like #245 was.

- Pushes to `release-please--branches--**` trigger a `sign-release-branch` job: when the head commit is unsigned (release-please commits via the REST API, which cannot sign; the **Update branch (rebase)** button also rewrites the commit unsigned), it amends the commit with silverhand-bot's GPG key (`BOT_GPG_KEY` / `BOT_GPG_PASSPHRASE` org secrets, same setup as logto-io/js) and force-pushes.
- All the master-line hardening is included from the start: `fetch-depth: 0` (a shallow amend orphans the commit — the #268 incident that auto-closed #245), the refuse-to-push-an-orphan guard, the skip-when-already-signed guard (no self-retriggering), and an explicit push refspec.
- The `release-please` job is gated to `v2.x` pushes; `target-branch: v2.x` and the `unmark-latest` job are untouched.
- RELEASE.md updated with the same paragraph as master.

Note: #260's branch predates this workflow, so its pushes won't trigger the job until the branch tree contains it — the first **Update branch (rebase)** on #260 after this merges brings the workflow in and the rebased commit gets signed automatically (the same live acceptance test as #270 on master). No rush either way: per the release ordering, #260 waits for 3.0.0 GA.

End-to-end precedent: on master this exact setup auto-signed the recreated release PR #270 (`d6233ea`, Verified, parent intact) with no human intervention.

## Testing

- Same job, verbatim, as the one that passed its live test on master today (#270 born Verified).
- v2.x-specific parts (`target-branch`, `unmark-latest`) untouched; the new job is additive.

## Checklist

- [ ] `.changeset` (N/A — release-please)
- [ ] unit tests (N/A — workflow change)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)