### PR TITLE
ci: keep Latest on the highest stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,19 +73,34 @@ jobs:
           fi
           git push --force origin HEAD:${{ github.ref_name }}
 
-  # GitHub marks the most recently created release as "Latest" by default,
-  # so a maintenance release cut here would steal the badge from the v3 line.
-  unmark-latest:
+  # GitHub marks the most recently created release as "Latest" by default, so a
+  # maintenance release cut here would steal the badge from the v3 line — and
+  # PATCHing the new release with make_latest=false does NOT demote a release
+  # that has already taken the badge (verified on v2.0.3). Assert the badge in
+  # the working direction instead: re-mark the highest stable version. While no
+  # v3 GA exists, the maintenance release IS the highest stable and correctly
+  # keeps the badge.
+  ensure-latest:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Unmark this release as latest
+      - name: Keep "Latest" on the highest stable release
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
-          release_id=$(gh api "repos/${{ github.repository }}/releases/tags/${{ needs.release-please.outputs.tag_name }}" --jq .id)
-          gh api -X PATCH "repos/${{ github.repository }}/releases/$release_id" -f make_latest=false
+          highest=$(gh api "repos/${{ github.repository }}/releases?per_page=100" \
+            --jq '[.[] | select(.prerelease == false and .draft == false
+                               and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")))]
+                  | max_by(.tag_name | ltrimstr("v") | split(".") | map(tonumber))
+                  | .tag_name')
+          if [ "$highest" = "${{ needs.release-please.outputs.tag_name }}" ]; then
+            echo "This release ($highest) is the highest stable version and correctly keeps Latest"
+            exit 0
+          fi
+          release_id=$(gh api "repos/${{ github.repository }}/releases/tags/$highest" --jq .id)
+          gh api -X PATCH "repos/${{ github.repository }}/releases/$release_id" -f make_latest=true
+          echo "Latest re-pointed at $highest"
 
   publish:
     needs: release-please


### PR DESCRIPTION
## Summary

The `unmark-latest` job turned out to be a no-op: `PATCH make_latest=false` does not demote a release that has **already taken** the Latest badge — verified live on v2.0.3 today (job green, badge unmoved). Right now that is harmless, even correct: v3 only has prereleases (which cannot hold Latest), so v2.0.3 genuinely is the newest stable. But the job exists for the case **after 3.0.0 GA**, where a v2 patch would steal the badge from v3 — and there it would silently fail.

Replaced with an `ensure-latest` job that asserts the badge in the direction that provably works (`make_latest=true`):

- list all non-draft, non-prerelease releases with strictly `vX.Y.Z` tags;
- pick the **highest version** (semver-ordered via jq `max_by`, not creation date);
- if that is the release just published → it deserves the badge, do nothing (today's case);
- otherwise → `PATCH make_latest=true` on the highest one, which re-points the badge (the v2 patch is demoted implicitly, since only one release can be Latest).

Version-ordered rather than v3-hardcoded, so it also covers future lines (e.g. a v3 patch after a v4 GA).

## Testing

- The selection query was run against the live repo: it returns `v2.0.3` today (= the just-created release → no-op path, correct), and would return the v3 GA tag once one exists.
- The no-op nature of `make_latest=false` on an already-latest release is today's observed behavior, not speculation.

## Checklist

- [ ] `.changeset` (N/A — release-please)
- [ ] unit tests (N/A — workflow change)
- [ ] integration tests (N/A)
- [ ] necessary KDoc comments (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)